### PR TITLE
Phase 2: First-run setup and LinkedIn import

### DIFF
--- a/DIST_README.md
+++ b/DIST_README.md
@@ -158,4 +158,5 @@ If a button appears to do nothing:
 - Refresh the browser tab.
 - Check Admin > Runtime status.
 - Check Admin > Background jobs.
+- If a LinkedIn import says no rows were found, upload the unzipped `Connections.csv` file from the LinkedIn export. Do not upload the ZIP file, a blank template, or a renamed file without LinkedIn connection rows.
 - For `Run Full Engine`, enter a Google Sheets Spreadsheet ID first, or use the local LinkedIn import workflow instead.

--- a/DIST_README.md
+++ b/DIST_README.md
@@ -1,6 +1,22 @@
 # BD Engine for Windows
 
-BD Engine runs locally on your Windows PC. The installer places the app files in your user profile and stores your working data separately in:
+BD Engine is a local business-development workspace for turning your relationship data into target accounts, contacts, follow-up priorities, and hiring signals.
+
+It runs on your Windows PC and opens in your browser. You do not need Git, Node.js, npm, SQLite tools, or manual PowerShell commands.
+
+## What BD Engine Does
+
+BD Engine helps you:
+
+- Import your LinkedIn `Connections.csv`
+- Turn people into contacts and companies into target accounts
+- Find accounts where you have relationship coverage
+- Track account status, owner, priority, outreach stage, notes, and next actions
+- Review contacts by company, title, score, and outreach status
+- Monitor background jobs such as imports, enrichment, and job-board discovery
+- Keep all working data on your own computer
+
+BD Engine is not a cloud service. The packaged Windows app stores your data locally in:
 
 `%LOCALAPPDATA%\BD Engine\Data`
 
@@ -11,54 +27,115 @@ That data folder is preserved when you update or uninstall unless you explicitly
 1. Run `BD-Engine-Setup.exe`.
 2. Keep the desktop shortcut selected unless you do not want one.
 3. Finish the installer.
+4. Launch `BD Engine` from the desktop or Start Menu.
 
-No Git, Node.js, npm, SQLite tools, or manual PowerShell commands are required.
+The launcher starts a local server at:
 
-## Launch
+`http://localhost:8173`
 
-Use either shortcut:
+It then opens your default browser. If BD Engine is already running, the launcher reuses the existing local server instead of starting a duplicate.
 
-- Desktop: `BD Engine`
-- Start Menu: `BD Engine`
+## First Launch
 
-The launcher starts the local BD Engine server on `http://localhost:8173`, waits for it to become ready, and opens your default browser.
-
-If BD Engine is already running, the launcher reuses the existing local server instead of starting another one.
-
-## First-Run Setup
-
-On a fresh install, BD Engine opens a setup wizard before the dashboard.
+On a fresh install, BD Engine opens a setup wizard.
 
 You will enter:
 
-- Your workspace or company name
+- Workspace or company name
 - Your name and email
-- Optional team/owner names
-- Your LinkedIn connections CSV, if you have it ready
+- Optional team or owner names
+- Optional LinkedIn `Connections.csv` import
 
-After setup is complete, future launches skip the wizard and open the normal dashboard.
+After setup is complete, future launches skip the wizard and open the dashboard.
 
 ## Import LinkedIn Connections
 
-LinkedIn lets you export your connections as a CSV file. In LinkedIn, request a copy of your data and choose the Connections export. When the archive is ready, unzip it and upload the included `Connections.csv` file in BD Engine.
+The fastest way to make BD Engine useful is to import your LinkedIn connections.
 
-BD Engine accepts the standard LinkedIn headers:
+To get the file from LinkedIn:
+
+1. Open LinkedIn in your browser.
+2. Go to Settings and Privacy.
+3. Find the data export or "Get a copy of your data" area.
+4. Choose the Connections export.
+5. Download and unzip the archive when LinkedIn sends it.
+6. In BD Engine, upload the included `Connections.csv` file.
+
+BD Engine accepts LinkedIn fields such as:
 
 `First Name, Last Name, URL, Email Address, Company, Position, Connected On`
 
-Missing email, company, title, or connected date fields are allowed. Before saving anything, the wizard shows a preview and summary of new, updated, skipped, and failed rows. Re-importing the same file updates existing contacts instead of creating duplicates.
+Missing email, company, title, or connected date fields are allowed. Re-importing the same file updates existing contacts instead of creating duplicates.
 
 An empty template is included with the installed app at:
 
 `data-template\sample-linkedin-connections.csv`
 
-## Update
+## Main Screens
 
-Run the newer `BD-Engine-Setup.exe`. Your database, settings, logs, and import history remain in `%LOCALAPPDATA%\BD Engine\Data`.
+### Dashboard
 
-## Uninstall
+Use the dashboard to see the current state of your BD workspace: account coverage, follow-up opportunities, recommended actions, recent activity, and hiring or discovery signals.
 
-Use Windows Settings > Apps > Installed apps > BD Engine > Uninstall.
+### Accounts
+
+Accounts are companies you may want to pursue. Use this screen to:
+
+- Search and filter companies
+- Review target score, status, owner, priority, and hiring signals
+- Open an account detail page
+- Add notes and next actions
+- Update outreach or pipeline status
+
+### Contacts
+
+Contacts are people imported from LinkedIn or other sources. Use this screen to:
+
+- Search by name, company, title, or email
+- Filter by score or outreach status
+- Review relationship coverage at each account
+- Export contacts if needed
+
+### Jobs
+
+Jobs show hiring activity discovered from configured job boards and ATS sources. This helps identify accounts with current hiring motion.
+
+### Admin
+
+Admin contains setup, import, background-job, and maintenance tools.
+
+Most users will mainly use:
+
+- LinkedIn Connections CSV import
+- Runtime status
+- Background jobs
+- Account/config maintenance tools
+
+Some Admin buttons are for legacy or advanced workflows. In particular, `Run Full Engine` is the older Google Sheets pipeline. It requires a Google Sheets Spreadsheet ID and is not required for normal local use.
+
+## Common Workflow
+
+1. Launch BD Engine.
+2. Import your LinkedIn `Connections.csv`.
+3. Open Contacts to confirm people imported.
+4. Open Accounts to review companies created from those contacts.
+5. Prioritize accounts using score, hiring signals, title coverage, and notes.
+6. Update statuses and next actions as you work.
+7. Re-import LinkedIn periodically to refresh contacts without creating duplicates.
+
+## Updating BD Engine
+
+Run the newer `BD-Engine-Setup.exe`.
+
+Your database, settings, logs, and import history remain in:
+
+`%LOCALAPPDATA%\BD Engine\Data`
+
+## Uninstalling
+
+Use:
+
+Windows Settings > Apps > Installed apps > BD Engine > Uninstall
 
 The uninstaller asks whether to remove local BD Engine user data. Choose `No` if you want to keep your data for a future install.
 
@@ -68,10 +145,17 @@ Logs are stored in:
 
 `%LOCALAPPDATA%\BD Engine\Logs`
 
-If the app does not open, check:
+Useful log files:
 
 - `launcher.log`
 - `server.out.log`
 - `server.err.log`
 
 BD Engine uses port `8173`. If another app is using that port, close the other app and launch BD Engine again.
+
+If a button appears to do nothing:
+
+- Refresh the browser tab.
+- Check Admin > Runtime status.
+- Check Admin > Background jobs.
+- For `Run Full Engine`, enter a Google Sheets Spreadsheet ID first, or use the local LinkedIn import workflow instead.

--- a/DIST_README.md
+++ b/DIST_README.md
@@ -25,6 +25,33 @@ The launcher starts the local BD Engine server on `http://localhost:8173`, waits
 
 If BD Engine is already running, the launcher reuses the existing local server instead of starting another one.
 
+## First-Run Setup
+
+On a fresh install, BD Engine opens a setup wizard before the dashboard.
+
+You will enter:
+
+- Your workspace or company name
+- Your name and email
+- Optional team/owner names
+- Your LinkedIn connections CSV, if you have it ready
+
+After setup is complete, future launches skip the wizard and open the normal dashboard.
+
+## Import LinkedIn Connections
+
+LinkedIn lets you export your connections as a CSV file. In LinkedIn, request a copy of your data and choose the Connections export. When the archive is ready, unzip it and upload the included `Connections.csv` file in BD Engine.
+
+BD Engine accepts the standard LinkedIn headers:
+
+`First Name, Last Name, URL, Email Address, Company, Position, Connected On`
+
+Missing email, company, title, or connected date fields are allowed. Before saving anything, the wizard shows a preview and summary of new, updated, skipped, and failed rows. Re-importing the same file updates existing contacts instead of creating duplicates.
+
+An empty template is included with the installed app at:
+
+`data-template\sample-linkedin-connections.csv`
+
 ## Update
 
 Run the newer `BD-Engine-Setup.exe`. Your database, settings, logs, and import history remain in `%LOCALAPPDATA%\BD Engine\Data`.

--- a/DIST_README.md
+++ b/DIST_README.md
@@ -125,6 +125,12 @@ Some Admin buttons are for legacy or advanced workflows. In particular, `Run Ful
 6. Update statuses and next actions as you work.
 7. Re-import LinkedIn periodically to refresh contacts without creating duplicates.
 
+## Outreach Workflow
+
+From Contacts, click `Outreach` on a contact. BD Engine opens that contact's account, preselects the person, and generates an email plus LinkedIn message from the company's current hiring signals and open roles.
+
+BD Engine can open an email draft and copy/open the LinkedIn message, but it does not send messages directly from your email or LinkedIn account. After you send them, click `Log sent + follow-up` to add an outreach note, mark the contact/account as contacted, and create a one-week follow-up reminder.
+
 ## Updating BD Engine
 
 Run the newer `BD-Engine-Setup.exe`.

--- a/DIST_README.md
+++ b/DIST_README.md
@@ -67,6 +67,8 @@ BD Engine accepts LinkedIn fields such as:
 
 Missing email, company, title, or connected date fields are allowed. Re-importing the same file updates existing contacts instead of creating duplicates.
 
+Large LinkedIn exports can take several minutes. BD Engine queues the import in the background; contacts and accounts appear after the background job finishes. You can watch progress in Admin > Background jobs.
+
 An empty template is included with the installed app at:
 
 `data-template\sample-linkedin-connections.csv`

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -53,6 +53,7 @@ Included:
 - runtime-required `scripts\Sync-LiveJobBoardsConfig.ps1`
 - `BD-Engine-Launcher.ps1`
 - `data-template` with empty JSON/template files
+- header-only `data-template\sample-linkedin-connections.csv`
 - `DIST_README.md`, `PACKAGING.md`, `README.md`, and `VERSION`
 
 Excluded:
@@ -76,6 +77,16 @@ The packaged launcher sets:
 
 The backend modules use that environment variable for JSON state, SQLite state, background-job logs, PID files, and resolver mapping overrides. If the variable is absent, existing development behavior is preserved.
 
+## First-Run And LinkedIn Import
+
+Phase 2 adds a first-run setup wizard that is triggered by `/api/setup/status` when the packaged data store has no completed setup flag and no user records. The wizard stores workspace/user settings in the normal settings segment and imports LinkedIn connections through the existing contacts/accounts storage path.
+
+The guided import accepts LinkedIn `Connections.csv` headers including:
+
+`First Name, Last Name, URL, Email Address, Company, Position, Connected On`
+
+The backend preview and final import share the same normalizer/dedupe logic. Customer packages still stage only empty data templates and the header-only sample CSV; no personal LinkedIn export is included.
+
 ## Validation Checklist
 
 1. Run `scripts\package-windows.ps1`.
@@ -85,15 +96,16 @@ The backend modules use that environment variable for JSON state, SQLite state, 
 5. Confirm the browser opens to `http://localhost:8173`.
 6. Confirm `http://localhost:8173/api/runtime/status` responds.
 7. Add or import a small test record.
-8. Close and relaunch BD Engine; confirm the data remains.
-9. Install the same or newer version over the existing install; confirm data remains.
-10. Uninstall and choose `No` when asked to remove user data; confirm `%LOCALAPPDATA%\BD Engine\Data` remains.
-11. Inspect `dist\windows\app` and confirm no personal/demo data or credentials are present.
+8. On a fresh data directory, confirm the setup wizard appears before the dashboard.
+9. Complete setup with a small LinkedIn-style CSV and confirm the dashboard, accounts, and contacts populate.
+10. Re-import the same CSV and confirm contacts are updated, not duplicated.
+11. Close and relaunch BD Engine; confirm setup is skipped and data remains.
+12. Install the same or newer version over the existing install; confirm data remains.
+13. Uninstall and choose `No` when asked to remove user data; confirm `%LOCALAPPDATA%\BD Engine\Data` remains.
+14. Inspect `dist\windows\app` and confirm no personal/demo data or credentials are present.
 
-## Deferred To Phase 2
+## Deferred To Phase 3
 
-- First-run setup wizard polish
-- LinkedIn Connections CSV guided import flow
 - Optional launch-at-startup support
 - Signed installer and signed launcher executable
 - Rich installer branding/icon assets

--- a/app/app.js
+++ b/app/app.js
@@ -1,3 +1,28 @@
+const defaultAdminCollapsed = {
+  'enrichment-coverage': true,
+  'enrichment-queue': true,
+  'resolver-coverage': true,
+  'runtime-status': true,
+  'background-jobs': true,
+  'pipeline-ops': true,
+  'scoring-settings': true,
+  'automation-rules': true,
+  'alert-thresholds': true,
+  'ats-config-form': true,
+  'ats-config-records': true,
+};
+
+function readJsonSetting(key, fallback) {
+  try {
+    const raw = localStorage.getItem(key);
+    return raw ? JSON.parse(raw) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+const savedAdminCollapsed = readJsonSetting('bd_admin_collapsed', null);
+
 const appState = {
   bootstrap: null,
   localData: null,
@@ -15,7 +40,9 @@ const appState = {
   runtimeStatus: null,
   runtimePollTimer: null,
   savedFilters: JSON.parse(localStorage.getItem('bd_saved_filters') || '[]'),
-  adminCollapsed: {},
+  adminCollapsed: savedAdminCollapsed && typeof savedAdminCollapsed === 'object'
+    ? { ...defaultAdminCollapsed, ...savedAdminCollapsed }
+    : { ...defaultAdminCollapsed },
   showAdvancedFilters: false,
   outreachModalOpen: false,
   statusPillsExpanded: false,
@@ -78,6 +105,39 @@ const themeToggle = document.getElementById('theme-toggle');
 const themeIcon = document.getElementById('theme-icon');
 const themeLabel = document.getElementById('theme-label');
 const hamburgerBtn = document.getElementById('mobile-hamburger');
+
+const defaultQueries = {
+  accounts: { page: 1, pageSize: 20, q: '', hiring: '', ats: '', recencyDays: '', minContacts: '', minTargetScore: '', priority: '', status: '', owner: '', outreachStatus: '', industry: '', geography: '', sortBy: '' },
+  contacts: { page: 1, pageSize: 20, q: '', minScore: '', outreachStatus: '' },
+  jobs: { page: 1, pageSize: 20, q: '', ats: '', recencyDays: '', active: 'true', isNew: '', sortBy: '' },
+  configs: { page: 1, pageSize: 20, q: '', ats: '', active: '', discoveryStatus: '', confidenceBand: '', reviewStatus: '' },
+  enrichment: { page: 1, pageSize: 20, confidence: '', missingDomain: '', missingCareersUrl: '', hasConnections: '', minTargetScore: '', topN: '' },
+};
+
+function resetViewFilters(view) {
+  if (view === 'accounts') {
+    appState.accountQuery = { ...defaultQueries.accounts };
+    appState.showAdvancedFilters = false;
+    return renderAccountsView();
+  }
+  if (view === 'contacts') {
+    appState.contactQuery = { ...defaultQueries.contacts };
+    return renderContactsView();
+  }
+  if (view === 'jobs') {
+    appState.jobQuery = { ...defaultQueries.jobs };
+    return renderJobsView();
+  }
+  if (view === 'configs') {
+    appState.configQuery = { ...defaultQueries.configs };
+    return renderAdminView();
+  }
+  if (view === 'enrichment') {
+    appState.enrichmentQuery = { ...defaultQueries.enrichment };
+    return refreshEnrichmentPanel();
+  }
+  return Promise.resolve();
+}
 
 /* ── Theme system ── */
 function applyTheme(mode) {
@@ -1678,6 +1738,19 @@ function bindEvents() {
       if (name) { saveFilter(name.trim()); await renderAccountsView(); }
       return;
     }
+    if (actionName === 'reset-filters') {
+      await resetViewFilters(action.dataset.view);
+      showToast('Filters reset.', 'info');
+      return;
+    }
+    if (actionName === 'apply-account-preset') {
+      await applyAccountPreset(action.dataset.preset, { navigate: action.dataset.navigate === 'accounts' });
+      return;
+    }
+    if (actionName === 'open-admin-section') {
+      openAdminSection(action.dataset.sectionId);
+      return;
+    }
     if (actionName === 'load-saved-filter') {
       applySavedFilter(action.dataset.name);
       await renderAccountsView();
@@ -1738,7 +1811,7 @@ function bindEvents() {
     }
 
     if (actionName === 'run-live-import') {
-      await runLiveImport();
+      await runLiveImport(action);
       return;
     }
 
@@ -1748,7 +1821,7 @@ function bindEvents() {
     }
 
     if (actionName === 'run-discovery') {
-      await runDiscovery();
+      await runDiscovery(action);
       return;
     }
 
@@ -1763,7 +1836,7 @@ function bindEvents() {
     }
 
     if (actionName === 'run-target-score-rollout') {
-      await runTargetScoreRollout();
+      await runTargetScoreRollout(action);
       return;
     }
 
@@ -2305,11 +2378,172 @@ function applySavedFilter(name) {
   }
 }
 
+const accountPresets = [
+  {
+    id: 'hot-hiring',
+    label: 'Hot hiring',
+    description: 'Active roles and target score 70+',
+    query: { hiring: 'true', minTargetScore: '70', sortBy: '' },
+  },
+  {
+    id: 'fresh-roles',
+    label: 'Recent roles',
+    description: 'Hiring movement in the last 30 days',
+    query: { hiring: 'true', recencyDays: '30', sortBy: 'new_roles' },
+  },
+  {
+    id: 'warm-network',
+    label: 'Warm network',
+    description: 'Accounts with mapped relationships first',
+    query: { minContacts: '1', sortBy: 'connections' },
+  },
+  {
+    id: 'follow-up',
+    label: 'Follow-up lane',
+    description: 'Work the accounts most due for action',
+    query: { sortBy: 'follow_up' },
+  },
+  {
+    id: 'strategic',
+    label: 'Strategic targets',
+    description: 'Highest-priority named accounts',
+    query: { priority: 'strategic', sortBy: '' },
+  },
+];
+
+const accountFilterLabels = {
+  q: 'Search',
+  hiring: 'Hiring',
+  ats: 'ATS',
+  recencyDays: 'Recency',
+  minContacts: 'Contacts',
+  minTargetScore: 'Score',
+  priority: 'Priority',
+  status: 'Status',
+  owner: 'Owner',
+  outreachStatus: 'Outreach',
+  industry: 'Industry',
+  geography: 'Geography',
+  sortBy: 'Sort',
+};
+
+function getAccountPreset(id) {
+  return accountPresets.find((preset) => preset.id === id);
+}
+
+function normalizedFilterEntries(query) {
+  return Object.entries(query || {})
+    .filter(([key, value]) => key !== 'page' && key !== 'pageSize' && value !== '' && value !== null && value !== undefined)
+    .map(([key, value]) => [key, String(value)]);
+}
+
+function isAccountPresetActive(preset) {
+  const activeEntries = normalizedFilterEntries(appState.accountQuery);
+  const presetEntries = normalizedFilterEntries(preset.query);
+  return activeEntries.length === presetEntries.length
+    && presetEntries.every(([key, value]) => String(appState.accountQuery[key] || '') === value);
+}
+
+async function applyAccountPreset(presetId, options = {}) {
+  const preset = getAccountPreset(presetId);
+  if (!preset) return;
+  const alreadyOnAccounts = getRouteRoot() === 'accounts';
+  appState.accountQuery = {
+    ...defaultQueries.accounts,
+    pageSize: appState.accountQuery.pageSize || defaultQueries.accounts.pageSize,
+    ...preset.query,
+    page: 1,
+  };
+  appState.showAdvancedFilters = false;
+  showToast(`${preset.label} lane applied.`, 'info');
+  if (options.navigate || !alreadyOnAccounts) {
+    location.hash = '#/accounts';
+    if (alreadyOnAccounts) await renderAccountsView();
+    return;
+  }
+  await renderAccountsView();
+}
+
 function renderSavedFilters() {
   if (!appState.savedFilters.length) return '';
   return `<div class="saved-filters-bar">${appState.savedFilters.map(f =>
     `<span class="saved-filter-chip"><button class="ghost-button ghost-button--xs" data-action="load-saved-filter" data-name="${escapeAttr(f.name)}">${escapeHtml(f.name)}</button><button class="saved-filter-delete" data-action="delete-saved-filter" data-name="${escapeAttr(f.name)}" aria-label="Delete filter ${escapeAttr(f.name)}">&times;</button></span>`
   ).join('')}</div>`;
+}
+
+function renderActiveFilterStrip(query, labels = accountFilterLabels) {
+  const entries = normalizedFilterEntries(query);
+  if (!entries.length) {
+    return '<div class="active-filter-strip active-filter-strip--empty"><span>All accounts visible</span></div>';
+  }
+  return `
+    <div class="active-filter-strip">
+      <span>${formatNumber(entries.length)} active filter${entries.length === 1 ? '' : 's'}</span>
+      ${entries.map(([key, value]) => `<span class="filter-chip"><strong>${escapeHtml(labels[key] || humanize(key))}</strong>${escapeHtml(humanize(value))}</span>`).join('')}
+      <button class="ghost-button ghost-button--xs" type="button" data-action="reset-filters" data-view="accounts">Clear</button>
+    </div>
+  `;
+}
+
+function renderAccountPresetStrip() {
+  return `
+    <section class="account-preset-strip" aria-label="Account working lanes">
+      <div class="preset-strip-copy">
+        <p class="eyebrow">Working lanes</p>
+        <strong>Jump to the queue that matches the moment.</strong>
+      </div>
+      <div class="preset-button-row">
+        ${accountPresets.map((preset) => `
+          <button class="preset-button${isAccountPresetActive(preset) ? ' active' : ''}" type="button" data-action="apply-account-preset" data-preset="${escapeAttr(preset.id)}">
+            <span>${escapeHtml(preset.label)}</span>
+            <small>${escapeHtml(preset.description)}</small>
+          </button>
+        `).join('')}
+      </div>
+    </section>
+  `;
+}
+
+function renderDashboardWorkflowStrip({ dashboard, extended, topCompany, resolutionPressure }) {
+  const freshJobs = dashboard.summary?.newJobsLast24h || 0;
+  const followUps = (extended.overdueFollowUps?.length || 0) + (extended.staleAccounts?.length || 0);
+  const boardsFound = dashboard.summary?.discoveredBoardCount || 0;
+  return `
+    <section class="workflow-strip" aria-label="Daily BD workflow">
+      <article class="workflow-card workflow-card--primary">
+        <span class="workflow-card__step">1</span>
+        <div class="workflow-card__copy">
+          <strong>${topCompany ? escapeHtml(topCompany.displayName) : 'Find the lead account'}</strong>
+          <span>${topCompany ? `${formatNumber(getTargetScore(topCompany))}/100 target score` : 'No top account yet'}</span>
+        </div>
+        ${topCompany ? `<button class="primary-button ghost-button--xs" type="button" data-action="open-account" data-id="${topCompany.id}">Open</button>` : '<a class="primary-button ghost-button--xs" href="#/admin">Seed</a>'}
+      </article>
+      <article class="workflow-card">
+        <span class="workflow-card__step">2</span>
+        <div class="workflow-card__copy">
+          <strong>Recent role triggers</strong>
+          <span>${formatNumber(freshJobs)} jobs in 24h</span>
+        </div>
+        <button class="ghost-button ghost-button--xs" type="button" data-action="apply-account-preset" data-preset="fresh-roles" data-navigate="accounts">Open lane</button>
+      </article>
+      <article class="workflow-card">
+        <span class="workflow-card__step">3</span>
+        <div class="workflow-card__copy">
+          <strong>Follow-up lane</strong>
+          <span>${formatNumber(followUps)} accounts need attention</span>
+        </div>
+        <button class="ghost-button ghost-button--xs" type="button" data-action="apply-account-preset" data-preset="follow-up" data-navigate="accounts">Open lane</button>
+      </article>
+      <article class="workflow-card">
+        <span class="workflow-card__step">4</span>
+        <div class="workflow-card__copy">
+          <strong>Coverage backlog</strong>
+          <span>${formatNumber(resolutionPressure)} identity gaps</span>
+        </div>
+        <a class="ghost-button ghost-button--xs" href="#/admin">${boardsFound ? 'Review' : 'Discover'}</a>
+      </article>
+    </section>
+  `;
 }
 
 function sleep(ms) {
@@ -2366,6 +2600,7 @@ function hydrateAdminRuntimePanels(runtime) {
         <div class="status-item"><span class="small muted">Running jobs</span><strong>${formatNumber(summary.runningJobs || 0)}</strong><span class="small muted">Currently executing</span></div>
         <div class="status-item"><span class="small muted">Queued jobs</span><strong>${formatNumber(summary.queuedJobs || 0)}</strong><span class="small muted">${summary.queuedJobs ? 'Waiting for worker time' : 'Queue clear'}</span></div>
       </div>
+      ${renderIngestionHealthPanel(summary)}
     </div>
   `;
 
@@ -3060,6 +3295,8 @@ async function renderDashboardView() {
       ${renderTrustCard('Audit trail', `${formatNumber(coverageEvents)} visible events`, 'Recent actions, imports, and board discovery remain reviewable.', `${formatNumber(dashboard.summary.newJobsLast24h || 0)} new jobs in 24h`, 'warning')}
     </section>`)}
 
+    ${dashSection('workflow', renderDashboardWorkflowStrip({ dashboard, extended, topCompany, resolutionPressure }))}
+
     ${dashSection('metrics', `<section class="metrics-grid">
       ${renderMetricCard('Accounts tracked', dashboard.summary.accountCount, 'Target accounts with contacts, configs, or imported jobs')}
       ${renderMetricCard('Hiring accounts', dashboard.summary.hiringAccountCount, 'Companies with active normalized roles')}
@@ -3339,6 +3576,8 @@ async function renderAccountsView() {
       </div>
     </section>
 
+    ${renderAccountPresetStrip()}
+
     <section class="detail-grid detail-grid--workspace">
       <div class="table-card">
         <div class="panel-header">
@@ -3364,6 +3603,7 @@ async function renderAccountsView() {
           <div class="field field--action">
             <button class="filter-toggle-btn" type="button" id="toggle-advanced-filters">${appState.showAdvancedFilters ? '\u25B2 Fewer filters' : '\u25BC More filters'}</button>
             <button class="primary-button" type="submit">Apply</button>
+            <button class="ghost-button" type="button" data-action="reset-filters" data-view="accounts">Reset</button>
             <button class="ghost-button" type="button" data-action="save-current-filter" aria-label="Save current filter">Save filter</button>
           </div>
           ${renderSavedFilters()}
@@ -3379,6 +3619,7 @@ async function renderAccountsView() {
           ${renderField('Outreach', `<select name="outreachStatus"><option value="">Any stage</option>${renderOutreachStageOptions(appState.accountQuery.outreachStatus, true)}</select>`)}
           </div>
         </form>
+        ${renderActiveFilterStrip(appState.accountQuery)}
         ${appState.kanbanMode
           ? (result.items.length ? renderKanbanBoard(result.items) : '<div class="empty-state"><div class="empty-state-icon">\uD83D\uDD0D</div>No accounts to show on the board.</div>')
           : (result.items.length ? renderAccountsTable(result.items) : '<div class="empty-state"><div class="empty-state-icon">\uD83D\uDD0D</div>No accounts match the current filters.<div class="empty-state-suggestion">Try broadening your search, or <strong>reset a filter</strong> to see more results.</div></div>')}
@@ -3766,7 +4007,7 @@ async function renderContactsView() {
         ${renderField('Search', `<input name="q" value="${escapeAttr(appState.contactQuery.q)}" placeholder="Name, company, title">`)}
         ${renderField('Min score', `<input name="minScore" type="number" min="0" value="${escapeAttr(appState.contactQuery.minScore)}">`)}
         ${renderField('Outreach', `<select name="outreachStatus"><option value="">Any stage</option><option value="not_started" ${selected(appState.contactQuery.outreachStatus, 'not_started')}>Not started</option><option value="researching" ${selected(appState.contactQuery.outreachStatus, 'researching')}>Researching</option><option value="ready_to_contact" ${selected(appState.contactQuery.outreachStatus, 'ready_to_contact')}>Ready to contact</option><option value="contacted" ${selected(appState.contactQuery.outreachStatus, 'contacted')}>Contacted</option><option value="replied" ${selected(appState.contactQuery.outreachStatus, 'replied')}>Replied</option><option value="opportunity" ${selected(appState.contactQuery.outreachStatus, 'opportunity')}>Opportunity</option></select>`)}
-        <div class="field field--action"><label>Refresh queue</label><button class="primary-button" type="submit">Apply filters</button></div>
+        <div class="field field--action"><label>Refresh queue</label><button class="primary-button" type="submit">Apply filters</button><button class="ghost-button" type="button" data-action="reset-filters" data-view="contacts">Reset</button></div>
       </form>
       ${result.items.length ? renderContactsTable(result.items) : '<div class="empty-state">No contacts match the current filters.</div>'}
       ${renderPagination('contacts', result.page, result.pageSize, result.total)}
@@ -3806,7 +4047,7 @@ async function renderJobsView() {
         ${renderField('Active', `<select name="active"><option value="">All</option><option value="true" ${selected(appState.jobQuery.active, 'true')}>Active only</option><option value="false" ${selected(appState.jobQuery.active, 'false')}>Inactive only</option></select>`)}
         ${renderField('New jobs', `<select name="isNew"><option value="">All</option><option value="true" ${selected(appState.jobQuery.isNew, 'true')}>New this sync</option><option value="false" ${selected(appState.jobQuery.isNew, 'false')}>Existing</option></select>`)}
         ${renderField('Sort by', `<select name="sortBy"><option value="">Posted date</option><option value="retrieved" ${selected(appState.jobQuery.sortBy, 'retrieved')}>Retrieved date</option></select>`)}
-        <div class="field field--action"><label>Refresh queue</label><button class="primary-button" type="submit">Apply filters</button></div>
+        <div class="field field--action"><label>Refresh queue</label><button class="primary-button" type="submit">Apply filters</button><button class="ghost-button" type="button" data-action="reset-filters" data-view="jobs">Reset</button></div>
       </form>
       ${result.items.length ? renderJobsTable(result.items) : '<div class="empty-state">No jobs match the current filter set.</div>'}
       ${renderPagination('jobs', result.page, result.pageSize, result.total)}
@@ -3816,7 +4057,7 @@ async function renderJobsView() {
 
 function renderCollapsibleStart(sectionId, title, subtitle) {
   const collapsed = appState.adminCollapsed[sectionId];
-  return `<div class="form-card">
+  return `<div class="form-card admin-section" id="admin-section-${escapeAttr(sectionId)}">
     <div class="collapsible-header${collapsed ? ' collapsed' : ''}" data-collapse-id="${escapeAttr(sectionId)}">
       <div class="panel-header" style="margin:0;flex:1"><div><h3>${escapeHtml(title)}</h3>${subtitle ? `<p class="muted small">${subtitle}</p>` : ''}</div></div>
       <span class="chevron">\u25BC</span>
@@ -3828,24 +4069,99 @@ function renderCollapsibleEnd() {
   return `</div></div>`;
 }
 
+function persistAdminCollapsed() {
+  localStorage.setItem('bd_admin_collapsed', JSON.stringify(appState.adminCollapsed));
+}
+
+function setCollapsibleState(header, isCollapsed) {
+  const id = header.dataset.collapseId;
+  const body = header.nextElementSibling;
+  header.classList.toggle('collapsed', isCollapsed);
+  body?.classList.toggle('collapsed', isCollapsed);
+  header.setAttribute('aria-expanded', isCollapsed ? 'false' : 'true');
+  appState.adminCollapsed[id] = isCollapsed;
+  persistAdminCollapsed();
+}
+
 function wireCollapsibleSections() {
   document.querySelectorAll('.collapsible-header[data-collapse-id]').forEach((header) => {
     header.setAttribute('role', 'button');
     header.setAttribute('tabindex', '0');
     header.setAttribute('aria-expanded', header.classList.contains('collapsed') ? 'false' : 'true');
     const toggleCollapse = () => {
-      const id = header.dataset.collapseId;
-      const body = header.nextElementSibling;
-      const isCollapsed = header.classList.toggle('collapsed');
-      body.classList.toggle('collapsed', isCollapsed);
-      header.setAttribute('aria-expanded', isCollapsed ? 'false' : 'true');
-      appState.adminCollapsed[id] = isCollapsed;
+      setCollapsibleState(header, !header.classList.contains('collapsed'));
     };
     header.addEventListener('click', toggleCollapse);
     header.addEventListener('keydown', (e) => {
       if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleCollapse(); }
     });
   });
+}
+
+function openAdminSection(sectionId) {
+  const section = document.getElementById(`admin-section-${sectionId}`);
+  const header = section?.querySelector('.collapsible-header[data-collapse-id]');
+  if (header) {
+    setCollapsibleState(header, false);
+    window.requestAnimationFrame(() => {
+      section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
+  }
+}
+
+function renderAdminCommandStrip({ summary, runtime, reviewQueueCount, enrichmentQueue, rolloutRemainingCount, rolloutActive }) {
+  const unresolvedCount = summary.unresolvedCount || 0;
+  const activeConfigs = summary.activeCount || 0;
+  const enrichmentCount = enrichmentQueue?.total || 0;
+  return `
+    <section class="admin-command-strip" aria-label="Admin command strip">
+      <article class="command-card command-card--warning">
+        <span class="command-card__step">1</span>
+        <div class="command-card__copy">
+          <strong>Review queue</strong>
+          <span>${formatNumber(reviewQueueCount)} config items</span>
+          <small>${formatNumber(enrichmentCount)} enrichment candidates</small>
+        </div>
+        <button class="ghost-button ghost-button--xs" type="button" data-action="open-admin-section" data-section-id="review-queues">Open</button>
+      </article>
+      <article class="command-card command-card--accent">
+        <span class="command-card__step">2</span>
+        <div class="command-card__copy">
+          <strong>Discover boards</strong>
+          <span>${formatNumber(unresolvedCount)} unresolved</span>
+          <small>Unresolved configs only</small>
+        </div>
+        <button class="secondary-button ghost-button--xs" type="button" data-action="run-discovery">Run</button>
+      </article>
+      <article class="command-card command-card--success">
+        <span class="command-card__step">3</span>
+        <div class="command-card__copy">
+          <strong>Import live jobs</strong>
+          <span>${formatNumber(activeConfigs)} active boards</span>
+          <small>${formatNumber(runtime.queuedJobs || 0)} jobs queued</small>
+        </div>
+        <button class="secondary-button ghost-button--xs" type="button" data-action="run-live-import">Import</button>
+      </article>
+      <article class="command-card ${rolloutActive ? 'command-card--accent' : (rolloutRemainingCount > 0 ? 'command-card--warning' : 'command-card--success')}">
+        <span class="command-card__step">4</span>
+        <div class="command-card__copy">
+          <strong>Score rollout</strong>
+          <span>${rolloutActive ? 'Worker active' : `${formatNumber(rolloutRemainingCount)} pending`}</span>
+          <small>Target intelligence fields</small>
+        </div>
+        <button class="primary-button ghost-button--xs" type="button" data-action="run-target-score-rollout"${(!rolloutActive && rolloutRemainingCount <= 0) ? ' disabled' : ''}>${rolloutActive ? 'Monitor' : (rolloutRemainingCount > 0 ? 'Run' : 'Done')}</button>
+      </article>
+      <article class="command-card">
+        <span class="command-card__step">Ops</span>
+        <div class="command-card__copy">
+          <strong>Pipeline panel</strong>
+          <span>Advanced controls</span>
+          <small>Discovery, enrichment, sheets</small>
+        </div>
+        <button class="ghost-button ghost-button--xs" type="button" data-action="open-admin-section" data-section-id="pipeline-ops">Open</button>
+      </article>
+    </section>
+  `;
 }
 
 async function renderAdminView() {
@@ -3971,6 +4287,8 @@ async function renderAdminView() {
       ${renderTrustCard('Coverage report', `${formatNumber(summary.coveragePercent || 0)}% board coverage`, 'See how much of the tracked universe is resolved and where review is still needed.', `${formatNumber(summary.resolvedCount || 0)} resolved boards`, 'success')}
       ${renderTrustCard('Review queue', `${formatNumber(reviewQueueCount)} items to inspect`, 'Medium-confidence and unresolved configs stay visible instead of disappearing into logs.', `${formatNumber(enrichmentQueue.total || 0)} enrichment candidates`, 'warning')}
     </section>
+
+    ${renderAdminCommandStrip({ summary, runtime, reviewQueueCount, enrichmentQueue, rolloutRemainingCount, rolloutActive })}
 
     <section class="admin-grid">
       <div class="two-column">
@@ -4189,7 +4507,7 @@ async function renderAdminView() {
             ${renderField('Confidence', `<select name="confidenceBand"><option value="">All</option>${(stateBootstrap.filters.configConfidenceBands || []).map((value) => `<option value="${escapeAttr(value)}" ${selected(appState.configQuery.confidenceBand, value)}>${escapeHtml(humanize(value))}</option>`).join('')}</select>`)}
             ${renderField('Review', `<select name="reviewStatus"><option value="">All</option>${(stateBootstrap.filters.configReviewStatuses || []).map((value) => `<option value="${escapeAttr(value)}" ${selected(appState.configQuery.reviewStatus, value)}>${escapeHtml(humanize(value))}</option>`).join('')}</select>`)}
             ${renderField('Active', `<select name="active"><option value="">All</option><option value="true" ${selected(appState.configQuery.active, 'true')}>Active</option><option value="false" ${selected(appState.configQuery.active, 'false')}>Inactive</option></select>`)}
-            <div class="field field--action"><label>Refresh queue</label><button class="primary-button" type="submit">Apply filters</button></div>
+            <div class="field field--action"><label>Refresh queue</label><button class="primary-button" type="submit">Apply filters</button><button class="ghost-button" type="button" data-action="reset-filters" data-view="configs">Reset</button></div>
           </form>
           ${configs.items.length ? renderConfigsTable(configs.items) : '<div class="empty-state">No config rows match the current filters.</div>'}
           ${renderPagination('configs', configs.page, configs.pageSize, configs.total)}
@@ -4397,11 +4715,12 @@ function renderEnrichmentFilters() {
         <option value="75" ${selected(q.minTargetScore, '75')}>Target score >= 75</option>
         <option value="90" ${selected(q.minTargetScore, '90')}>Target score >= 90</option>
       </select>
-      <button class="ghost-button" data-action="apply-enrichment-filter">Apply</button>
+      <button class="ghost-button" type="button" data-action="apply-enrichment-filter">Apply</button>
+      <button class="ghost-button" type="button" data-action="reset-filters" data-view="enrichment">Reset</button>
       <span class="small muted">Quick:</span>
-      <button class="ghost-button ghost-button--xs" data-action="enrichment-top-n" data-topn="100">Top 100</button>
-      <button class="ghost-button ghost-button--xs" data-action="enrichment-top-n" data-topn="250">Top 250</button>
-      <button class="ghost-button ghost-button--xs" data-action="enrichment-top-n" data-topn="">All</button>
+      <button class="ghost-button ghost-button--xs" type="button" data-action="enrichment-top-n" data-topn="100">Top 100</button>
+      <button class="ghost-button ghost-button--xs" type="button" data-action="enrichment-top-n" data-topn="250">Top 250</button>
+      <button class="ghost-button ghost-button--xs" type="button" data-action="enrichment-top-n" data-topn="">All</button>
     </div>
   `;
 }
@@ -4731,6 +5050,94 @@ function parseJobProgress(msg) {
   return { current, total, pct: Math.min(100, Math.round((current / total) * 100)) };
 }
 
+function getRuntimeJobs(runtime) {
+  const seen = new Set();
+  return [...(runtime?.activeJobs || []), ...(runtime?.recentJobs || [])].filter((job) => {
+    if (!job || !job.id || seen.has(job.id)) return false;
+    seen.add(job.id);
+    return true;
+  });
+}
+
+function getRuntimeJobDuration(job) {
+  if (!job) return '';
+  const started = Date.parse(job.startedAt || job.queuedAt || '');
+  if (!Number.isFinite(started)) return '';
+  const finished = Date.parse(job.finishedAt || '');
+  const end = Number.isFinite(finished) ? finished : Date.now();
+  const ms = Math.max(0, end - started);
+  const minutes = Math.floor(ms / 60000);
+  if (minutes < 1) return '<1m';
+  if (minutes < 90) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const rest = minutes % 60;
+  return `${hours}h ${rest}m`;
+}
+
+function getJobPhaseLabel(job) {
+  const message = job?.progressMessage || '';
+  if (!message || message === 'Completed') return humanize(job?.status || 'idle');
+  return message.split(' - ')[0] || message;
+}
+
+function renderIngestionHealthPanel(runtime) {
+  const jobs = getRuntimeJobs(runtime);
+  const liveImports = jobs.filter((job) => job.type === 'live-job-import');
+  const activeImport = liveImports.find((job) => ['queued', 'running'].includes(job.status));
+  const lastImport = liveImports.find((job) => job.status === 'completed') || liveImports[0];
+  const lastFailed = liveImports.find((job) => ['failed', 'cancelled'].includes(job.status));
+  const progress = activeImport ? parseJobProgress(activeImport.progressMessage) : null;
+  const activeLabel = activeImport
+    ? (progress ? `${formatNumber(progress.current)} / ${formatNumber(progress.total)}` : humanize(activeImport.status))
+    : 'Idle';
+  const activeMeta = activeImport
+    ? `${getJobPhaseLabel(activeImport)} · ${getRuntimeJobDuration(activeImport)} elapsed`
+    : 'No live import is currently active';
+  const lastDuration = lastImport && lastImport.status === 'completed' ? getRuntimeJobDuration(lastImport) : '';
+  const lastRecords = lastImport?.recordsAffected ? `${formatNumber(lastImport.recordsAffected)} records` : 'No records yet';
+  const lastMeta = lastImport
+    ? `${lastDuration || humanize(lastImport.status)} · ${lastRecords}`
+    : 'No completed imports found';
+  const failureMeta = lastFailed
+    ? `${humanize(lastFailed.status)} · ${formatDate(lastFailed.finishedAt || lastFailed.updatedAt || lastFailed.queuedAt)}`
+    : 'No recent live import failures';
+
+  return `
+    <div class="ingestion-health">
+      <div class="ingestion-health__head">
+        <div>
+          <p class="eyebrow">Ingestion health</p>
+          <strong>${activeImport ? 'Live import in progress' : 'Live import ready'}</strong>
+        </div>
+        ${activeImport ? renderStatusPill(activeImport.status || 'running', activeImport.status === 'running' ? 'warm' : 'neutral') : renderStatusPill('Ready', 'success')}
+      </div>
+      <div class="ingestion-health__grid">
+        <div class="ingestion-health__metric">
+          <span class="small muted">Active import</span>
+          <strong>${escapeHtml(activeLabel)}</strong>
+          <span class="small muted">${escapeHtml(activeMeta)}</span>
+        </div>
+        <div class="ingestion-health__metric">
+          <span class="small muted">Last import</span>
+          <strong>${escapeHtml(lastDuration || humanize(lastImport?.status || 'none'))}</strong>
+          <span class="small muted">${escapeHtml(lastMeta)}</span>
+        </div>
+        <div class="ingestion-health__metric">
+          <span class="small muted">Queue load</span>
+          <strong>${formatNumber((runtime?.runningJobs || 0) + (runtime?.queuedJobs || 0))}</strong>
+          <span class="small muted">${formatNumber(runtime?.runningJobs || 0)} running · ${formatNumber(runtime?.queuedJobs || 0)} queued</span>
+        </div>
+        <div class="ingestion-health__metric">
+          <span class="small muted">Recent failures</span>
+          <strong>${lastFailed ? 'Review' : 'Clear'}</strong>
+          <span class="small muted">${escapeHtml(failureMeta)}</span>
+        </div>
+      </div>
+      ${progress ? `<div class="spark-bar job-progress-bar ingestion-health__bar"><span style="width:${progress.pct}%"></span></div>` : ''}
+    </div>
+  `;
+}
+
 function renderBackgroundJobItem(job) {
   const tone = job.status === 'completed'
     ? 'success'
@@ -4919,8 +5326,8 @@ async function reseedWorkbook(path) {
   });
 }
 
-async function runLiveImport() {
-  await withButtonState('[data-action="run-live-import"]', 'Running import...', async () => {
+async function runLiveImport(buttonEl) {
+  await withButtonState(buttonEl || '[data-action="run-live-import"]', 'Running import...', async () => {
     const accepted = await api('/api/import/jobs', { method: 'POST', body: JSON.stringify({}) });
     showToast('Live ATS import queued.', 'success');
     const job = await watchBackgroundJob(accepted.jobId, { label: 'Live ATS import' });
@@ -4933,8 +5340,8 @@ async function runLiveImport() {
   });
 }
 
-async function runDiscovery() {
-  await withButtonState('[data-action="run-discovery"]', 'Discovering...', async () => {
+async function runDiscovery(buttonEl) {
+  await withButtonState(buttonEl || '[data-action="run-discovery"]', 'Discovering...', async () => {
     const limit = Number(document.getElementById('discovery-limit')?.value || 75);
     const onlyMissing = (document.getElementById('discovery-only-missing')?.value || 'true') === 'true';
     const forceRefresh = (document.getElementById('discovery-force-refresh')?.value || 'false') === 'true';
@@ -5000,8 +5407,8 @@ async function runEnrichment() {
   }
 }
 
-async function runTargetScoreRollout() {
-  const button = document.querySelector('[data-action="run-target-score-rollout"]');
+async function runTargetScoreRollout(buttonEl) {
+  const button = buttonEl || document.querySelector('[data-action="run-target-score-rollout"]');
   if (button) { button.disabled = true; button.textContent = 'Queueing rollout...'; }
   try {
     const limit = Number(document.getElementById('target-score-rollout-limit')?.value || appState.targetScoreRollout?.defaultLimit || 150);

--- a/app/app.js
+++ b/app/app.js
@@ -45,6 +45,7 @@ const appState = {
     : { ...defaultAdminCollapsed },
   showAdvancedFilters: false,
   outreachModalOpen: false,
+  pendingOutreachContact: null,
   statusPillsExpanded: false,
   previousScores: {},
   theme: localStorage.getItem('bd_theme') || 'system',
@@ -1547,8 +1548,7 @@ function bindEvents() {
       if (appState.mobileNavOpen) { closeMobileNav(); return; }
       const backdrop = document.getElementById('outreach-modal-backdrop');
       if (backdrop && !backdrop.classList.contains('hidden')) {
-        backdrop.classList.add('hidden');
-        appState.outreachModalOpen = false;
+        setOutreachModalOpen(false);
       }
       return;
     }
@@ -1646,14 +1646,8 @@ function bindEvents() {
   document.addEventListener('click', async (event) => {
     // Open outreach modal
     if (event.target.id === 'open-outreach-modal') {
-      const backdrop = document.getElementById('outreach-modal-backdrop');
-      if (backdrop) {
-        backdrop.classList.remove('hidden');
-        appState.outreachModalOpen = true;
-        syncOutreachComposerState();
-        const closeBtn = backdrop.querySelector('.modal-close');
-        if (closeBtn) closeBtn.focus();
-      }
+      setOutreachModalOpen(true);
+      syncOutreachComposerState();
       return;
     }
     // Advanced filter toggle
@@ -1666,8 +1660,7 @@ function bindEvents() {
     }
     // Outreach modal close
     if (event.target.closest('.modal-close') || (event.target.classList.contains('modal-backdrop') && !event.target.closest('.modal-panel'))) {
-      const backdrop = document.getElementById('outreach-modal-backdrop');
-      if (backdrop) { backdrop.classList.add('hidden'); appState.outreachModalOpen = false; }
+      setOutreachModalOpen(false);
       return;
     }
     // Status pills expand
@@ -1805,6 +1798,15 @@ function bindEvents() {
       return;
     }
 
+    if (actionName === 'open-contact-outreach' || actionName === 'select-contact-outreach') {
+      openOutreachForContact({
+        accountId: action.dataset.accountId || appState.accountDetail?.account?.id || '',
+        contactId: action.dataset.contactId || '',
+        contactName: action.dataset.contactName || '',
+      });
+      return;
+    }
+
     if (actionName === 'reseed-workbook') {
       await reseedWorkbook(action.dataset.path || '');
       return;
@@ -1913,6 +1915,11 @@ function bindEvents() {
 
     if (actionName === 'open-generated-linkedin') {
       await openGeneratedLinkedIn(action);
+      return;
+    }
+
+    if (actionName === 'log-generated-outreach') {
+      await logGeneratedOutreach(action);
       return;
     }
 
@@ -3818,7 +3825,7 @@ async function renderAccountDetail(accountId) {
         <div class="outreach-controls outreach-controls--stacked">
           <select id="outreach-contact-select" class="inline-select">
             ${detail.contacts.length
-              ? detail.contacts.map((c, i) => `<option value="${escapeAttr(c.fullName)}" data-title="${escapeAttr(c.title || '')}" data-contact-id="${escapeAttr(c.id || '')}"${i === 0 ? ' selected' : ''}>${escapeHtml(c.fullName)}${c.title ? ' \u2014 ' + escapeHtml(c.title) : ''}</option>`).join('')
+              ? detail.contacts.map((c, i) => `<option value="${escapeAttr(c.id || c.fullName || '')}" data-name="${escapeAttr(c.fullName || '')}" data-title="${escapeAttr(c.title || '')}" data-contact-id="${escapeAttr(c.id || '')}" data-email="${escapeAttr(c.email || '')}" data-linkedin-url="${escapeAttr(c.linkedinUrl || '')}" data-company="${escapeAttr(c.companyName || detail.account.displayName || '')}" data-notes="${escapeAttr(c.notes || '')}"${i === 0 ? ' selected' : ''}>${escapeHtml(c.fullName)}${c.title ? ' \u2014 ' + escapeHtml(c.title) : ''}</option>`).join('')
               : '<option value="">No contacts</option>'}
           </select>
           <select id="outreach-template-select" class="inline-select">
@@ -3849,8 +3856,8 @@ async function renderAccountDetail(accountId) {
       <div class="action-zone-col">
         <div class="table-card">
           <div class="panel-header"><div><h3>Top contacts</h3><p class="muted small">Click a name to open LinkedIn, or click anywhere else on the row to select for outreach.</p></div></div>
-          ${detail.contacts.length ? '<div class="table-scroll"><table class="table"><thead><tr><th>Contact</th><th>Title</th><th>Score</th><th>Connected</th></tr></thead><tbody>' +
-            detail.contacts.map((c) => '<tr class="contact-row-selectable" data-contact-name="' + escapeAttr(c.fullName) + '" data-contact-title="' + escapeAttr(c.title || '') + '"><td>' + (() => { const linkedinHref = getContactLinkedInHref(c, detail.account.displayName); return linkedinHref ? '<a class="row-link" href="' + escapeAttr(linkedinHref) + '" target="_blank" rel="noreferrer"><strong>' + escapeHtml(c.fullName || '') + '</strong></a>' : '<strong>' + escapeHtml(c.fullName || '') + '</strong>'; })() + '</td><td>' + escapeHtml(c.title || '') + '</td><td>' + formatNumber(c.priorityScore) + '</td><td>' + formatDate(c.connectedOn) + '</td></tr>').join('') +
+          ${detail.contacts.length ? '<div class="table-scroll"><table class="table"><thead><tr><th>Contact</th><th>Title</th><th>Score</th><th>Connected</th><th>Action</th></tr></thead><tbody>' +
+            detail.contacts.map((c) => '<tr class="contact-row-selectable" data-contact-id="' + escapeAttr(c.id || '') + '" data-contact-name="' + escapeAttr(c.fullName) + '" data-contact-title="' + escapeAttr(c.title || '') + '"><td>' + (() => { const linkedinHref = getContactLinkedInHref(c, detail.account.displayName); return linkedinHref ? '<a class="row-link" href="' + escapeAttr(linkedinHref) + '" target="_blank" rel="noreferrer"><strong>' + escapeHtml(c.fullName || '') + '</strong></a>' : '<strong>' + escapeHtml(c.fullName || '') + '</strong>'; })() + '</td><td>' + escapeHtml(c.title || '') + '</td><td>' + formatNumber(c.priorityScore) + '</td><td>' + formatDate(c.connectedOn) + '</td><td><button class="ghost-button ghost-button--xs" type="button" data-action="select-contact-outreach" data-account-id="' + escapeAttr(detail.account.id) + '" data-contact-id="' + escapeAttr(c.id || '') + '" data-contact-name="' + escapeAttr(c.fullName || '') + '">Outreach</button></td></tr>').join('') +
             '</tbody></table></div>' : '<div class="empty-state"><div class="empty-state-icon">\uD83D\uDC64</div>No contacts imported yet.<div class="empty-state-suggestion">Import a <strong>LinkedIn Connections CSV</strong> from the Admin view to populate contacts.</div></div>'}
         </div>
       </div>
@@ -3989,6 +3996,7 @@ async function renderAccountDetail(accountId) {
       </div>
     </section>
   `;
+  applyPendingOutreachContact(detail.account.id);
   syncOutreachComposerState();
   // Wire notes
   document.getElementById('add-note-btn')?.addEventListener('click', () => {
@@ -4655,7 +4663,7 @@ function renderAccountsTable(items) {
 
 function renderContactsTable(items) {
   return `
-    <div class="table-scroll"><table class="table"><thead><tr><th>Contact</th><th>Company</th><th>Title</th><th>Score</th><th>Connected</th><th>Status</th><th>Quick update</th></tr></thead><tbody>
+    <div class="table-scroll"><table class="table"><thead><tr><th>Contact</th><th>Company</th><th>Title</th><th>Score</th><th>Connected</th><th>Status</th><th>Actions</th></tr></thead><tbody>
       ${items.map((item) => `
         <tr>
           <td><strong>${escapeHtml(item.fullName)}</strong><div class="small muted">${item.linkedinUrl ? `<a class="row-link" href="${escapeAttr(item.linkedinUrl)}" target="_blank" rel="noreferrer">LinkedIn</a>` : 'No URL'}</div></td>
@@ -4664,7 +4672,12 @@ function renderContactsTable(items) {
           <td>${formatNumber(item.priorityScore)}</td>
           <td>${formatDate(item.connectedOn)}</td>
           <td>${renderStatusPill(item.outreachStatus || 'not_started', 'neutral')}</td>
-          <td><form id="contact-inline-form" data-contact-id="${item.id}" class="detail-form"><div class="inline-field"><label>Stage</label><select name="outreachStatus"><option value="not_started" ${selected(item.outreachStatus, 'not_started')}>Not started</option><option value="researching" ${selected(item.outreachStatus, 'researching')}>Researching</option><option value="ready_to_contact" ${selected(item.outreachStatus, 'ready_to_contact')}>Ready</option><option value="contacted" ${selected(item.outreachStatus, 'contacted')}>Contacted</option><option value="replied" ${selected(item.outreachStatus, 'replied')}>Replied</option><option value="opportunity" ${selected(item.outreachStatus, 'opportunity')}>Opportunity</option></select></div><div class="inline-field"><label>Notes</label><input name="notes" value="${escapeAttr(item.notes || '')}" placeholder="Short note"></div><button class="ghost-button" type="submit">Save</button></form></td>
+          <td>
+            <div class="button-row button-row--wrap">
+              <button class="ghost-button ghost-button--xs" type="button" data-action="open-contact-outreach" data-account-id="${escapeAttr(item.accountId || '')}" data-contact-id="${escapeAttr(item.id || '')}" data-contact-name="${escapeAttr(item.fullName || '')}" ${item.accountId ? '' : 'disabled'}>Outreach</button>
+            </div>
+            <form id="contact-inline-form" data-contact-id="${item.id}" class="detail-form"><div class="inline-field"><label>Stage</label><select name="outreachStatus"><option value="not_started" ${selected(item.outreachStatus, 'not_started')}>Not started</option><option value="researching" ${selected(item.outreachStatus, 'researching')}>Researching</option><option value="ready_to_contact" ${selected(item.outreachStatus, 'ready_to_contact')}>Ready</option><option value="contacted" ${selected(item.outreachStatus, 'contacted')}>Contacted</option><option value="replied" ${selected(item.outreachStatus, 'replied')}>Replied</option><option value="opportunity" ${selected(item.outreachStatus, 'opportunity')}>Opportunity</option></select></div><div class="inline-field"><label>Notes</label><input name="notes" value="${escapeAttr(item.notes || '')}" placeholder="Short note"></div><button class="ghost-button" type="submit">Save</button></form>
+          </td>
         </tr>`).join('')}
     </tbody></table></div>`;
 }
@@ -5718,6 +5731,7 @@ document.addEventListener('change', (event) => {
     return;
   }
   if (event.target.id === 'outreach-template-select' || event.target.id === 'outreach-contact-select') {
+    clearGeneratedOutreachDraft('Generate a fresh note for the selected contact and angle.');
     syncOutreachComposerState();
     return;
   }
@@ -5734,13 +5748,7 @@ document.addEventListener('click', (event) => {
       return;
     }
     const name = contactRow.dataset.contactName;
-    const sel = document.getElementById('outreach-contact-select');
-    if (sel) {
-      sel.value = name;
-      document.querySelectorAll('.contact-row-selectable').forEach(r => r.classList.remove('selected'));
-      contactRow.classList.add('selected');
-      syncOutreachComposerState();
-    }
+    selectOutreachContact({ contactId: contactRow.dataset.contactId || '', contactName: name });
   }
 });
 
@@ -5794,7 +5802,7 @@ async function generateSmartOutreachLegacy(accountId, buttonEl) {
     // Get selected contact from dropdown
     const contactSelect = document.getElementById('outreach-contact-select');
     const selectedOption = contactSelect?.selectedOptions?.[0];
-    const contactName = selectedOption?.value || '';
+    const contactName = selectedOption?.dataset?.name || selectedOption?.value || '';
     const contactTitle = selectedOption?.dataset?.title || '';
 
     const result = await api(`/api/accounts/${accountId}/generate-outreach`, {
@@ -5898,6 +5906,206 @@ function getSuggestedOutreachTemplate(detail) {
   return 'cold';
 }
 
+function getSelectedOutreachContact() {
+  const contactSelect = document.getElementById('outreach-contact-select');
+  const selectedOption = contactSelect?.selectedOptions?.[0];
+  if (!selectedOption) {
+    return { id: '', name: '', title: '', email: '', linkedinUrl: '', companyName: '', notes: '' };
+  }
+
+  return {
+    id: selectedOption.dataset.contactId || '',
+    name: selectedOption.dataset.name || selectedOption.value || '',
+    title: selectedOption.dataset.title || '',
+    email: selectedOption.dataset.email || '',
+    linkedinUrl: selectedOption.dataset.linkedinUrl || '',
+    companyName: selectedOption.dataset.company || appState.accountDetail?.account?.displayName || '',
+    notes: selectedOption.dataset.notes || '',
+  };
+}
+
+function selectOutreachContact({ contactId = '', contactName = '' } = {}) {
+  const contactSelect = document.getElementById('outreach-contact-select');
+  if (!contactSelect) return false;
+
+  const normalizedName = String(contactName || '').trim().toLowerCase();
+  const option = Array.from(contactSelect.options).find((item) => {
+    const optionId = item.dataset.contactId || '';
+    const optionName = String(item.dataset.name || item.value || '').trim().toLowerCase();
+    return (contactId && optionId === contactId) || (normalizedName && optionName === normalizedName);
+  });
+  if (!option) return false;
+
+  const previousValue = contactSelect.value;
+  contactSelect.value = option.value;
+  if (previousValue !== option.value) {
+    clearGeneratedOutreachDraft('Generate a fresh note for the selected contact.');
+  }
+  document.querySelectorAll('.contact-row-selectable').forEach((row) => {
+    row.classList.toggle('selected', Boolean(
+      (contactId && row.dataset.contactId === contactId) ||
+      (normalizedName && String(row.dataset.contactName || '').trim().toLowerCase() === normalizedName)
+    ));
+  });
+  syncOutreachComposerState();
+  return true;
+}
+
+function clearGeneratedOutreachDraft(message = '') {
+  if (!appState.generatedOutreach) return;
+  appState.generatedOutreach = null;
+  const body = document.getElementById('outreach-prompt-body');
+  if (body) {
+    body.className = 'empty-state empty-state--compact';
+    body.textContent = message || 'Generate a fresh outreach draft for this contact.';
+  }
+}
+
+function setOutreachModalOpen(isOpen) {
+  appState.outreachModalOpen = Boolean(isOpen);
+  const backdrop = document.getElementById('outreach-modal-backdrop');
+  if (backdrop) {
+    backdrop.classList.toggle('hidden', !appState.outreachModalOpen);
+    if (appState.outreachModalOpen) {
+      window.requestAnimationFrame(() => {
+        backdrop.querySelector('#outreach-contact-select, button, a, input, select, textarea')?.focus();
+      });
+    }
+  }
+}
+
+function applyPendingOutreachContact(accountId) {
+  const pending = appState.pendingOutreachContact;
+  if (!pending || String(pending.accountId || '') !== String(accountId || '')) return;
+  selectOutreachContact({ contactId: pending.contactId, contactName: pending.contactName });
+  setOutreachModalOpen(true);
+  appState.pendingOutreachContact = null;
+}
+
+function openOutreachForContact({ accountId = '', contactId = '', contactName = '' } = {}) {
+  if (!accountId) {
+    showToast('This contact is not attached to an account yet.', 'warning');
+    return;
+  }
+
+  appState.pendingOutreachContact = { accountId, contactId, contactName };
+  appState.outreachModalOpen = true;
+  if (appState.accountDetail?.account?.id === accountId && getRouteRoot() === 'accounts') {
+    applyPendingOutreachContact(accountId);
+    return;
+  }
+  location.hash = `#/accounts/${accountId}`;
+}
+
+function getFutureDateInput(days = 7) {
+  const date = new Date();
+  date.setDate(date.getDate() + days);
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${date.getFullYear()}-${month}-${day}`;
+}
+
+function buildOutreachLogNotes(outreach, contact, followUpAt) {
+  const lines = [
+    `Channels: email + LinkedIn`,
+    contact.email ? `Email: ${contact.email}` : '',
+    contact.linkedinUrl ? `LinkedIn: ${contact.linkedinUrl}` : '',
+    outreach.subjectLine ? `Subject: ${outreach.subjectLine}` : '',
+    outreach.messageBody ? `Email draft:\n${outreach.messageBody}` : '',
+    outreach.linkedinMessage ? `LinkedIn draft:\n${outreach.linkedinMessage}` : '',
+    `Follow-up reminder: ${followUpAt}`,
+  ];
+  return lines.filter(Boolean).join('\n\n');
+}
+
+async function logGeneratedOutreach(buttonEl) {
+  const outreach = appState.generatedOutreach;
+  const detail = appState.accountDetail;
+  if (!outreach || !detail?.account) {
+    showToast('Generate an outreach draft first.', 'warning');
+    return;
+  }
+
+  const account = detail.account;
+  const contact = getSelectedOutreachContact();
+  const contactLabel = contact.name || 'selected contact';
+  const followUpAt = getFutureDateInput(7);
+  const today = getFutureDateInput(0);
+  const summary = `Sent email + LinkedIn outreach to ${contactLabel}`;
+  const notes = buildOutreachLogNotes(outreach, contact, followUpAt);
+  const originalText = buttonEl?.textContent || '';
+  if (buttonEl) {
+    buttonEl.disabled = true;
+    buttonEl.textContent = 'Logging...';
+  }
+
+  try {
+    await api('/api/activity', {
+      method: 'POST',
+      body: JSON.stringify({
+        accountId: account.id,
+        contactId: contact.id,
+        normalizedCompanyName: account.normalizedName,
+        type: 'outreach',
+        summary,
+        notes,
+        pipelineStage: 'contacted',
+        metadata: {
+          channels: ['email', 'linkedin'],
+          subjectLine: outreach.subjectLine || '',
+          contactName: contact.name || '',
+          contactEmail: contact.email || '',
+          linkedinUrl: contact.linkedinUrl || '',
+          followUpAt,
+        },
+      }),
+    });
+
+    const accountPatch = {
+      outreachStatus: 'contacted',
+      nextAction: `Follow up with ${contactLabel}`,
+      nextActionAt: followUpAt,
+    };
+    if (!['client', 'in_conversation'].includes(String(account.status || '').toLowerCase())) {
+      accountPatch.status = 'contacted';
+    }
+    await api(`/api/accounts/${account.id}`, {
+      method: 'PATCH',
+      body: JSON.stringify(accountPatch),
+    });
+
+    if (contact.id) {
+      const contactNote = `Outreach sent ${today}: email + LinkedIn. Follow up ${followUpAt}.`;
+      const mergedNotes = [contact.notes, contactNote].filter(Boolean).join('\n');
+      await api(`/api/contacts/${contact.id}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ outreachStatus: 'contacted', notes: mergedNotes }),
+      });
+    }
+
+    appState.outreachSequences.push({
+      id: Date.now(),
+      accountId: account.id,
+      channel: 'follow_up',
+      note: `Follow up with ${contactLabel} after email + LinkedIn outreach`,
+      dueAt: new Date(`${followUpAt}T09:00:00`).toISOString(),
+      done: false,
+    });
+    localStorage.setItem('bd_sequences', JSON.stringify(appState.outreachSequences));
+    logActivity('outreach_logged', { accountId: account.id, summary });
+    invalidateAppData();
+    showToast(`Outreach logged. Follow-up set for ${formatDate(followUpAt)}.`, 'success', 7000);
+    await renderAccountDetail(account.id);
+  } catch (error) {
+    showToast(`Could not log outreach: ${error.message || error}`, 'error', 7000);
+  } finally {
+    if (buttonEl) {
+      buttonEl.disabled = false;
+      buttonEl.textContent = originalText;
+    }
+  }
+}
+
 function syncOutreachComposerState() {
   const templateSelect = document.getElementById('outreach-template-select');
   const contactSelect = document.getElementById('outreach-contact-select');
@@ -5905,7 +6113,7 @@ function syncOutreachComposerState() {
   const bundleButton = document.getElementById('generate-outreach-bundle-button');
   if (!button || !templateSelect) return;
   const meta = getOutreachTemplateMeta(templateSelect.value || 'cold');
-  const selectedContact = contactSelect?.selectedOptions?.[0]?.value || '';
+  const selectedContact = contactSelect?.selectedOptions?.[0]?.dataset?.name || contactSelect?.selectedOptions?.[0]?.value || '';
   button.textContent = selectedContact ? `${meta.buttonLabel} for ${selectedContact}` : meta.buttonLabel;
   if (bundleButton) {
     bundleButton.textContent = selectedContact ? `Generate 3 angles for ${selectedContact}` : 'Generate 3 angles';
@@ -6005,6 +6213,10 @@ function renderGeneratedOutreachVariants(outreach) {
 function renderGeneratedOutreach(outreach) {
   const gmailSubject = encodeURIComponent(outreach.subjectLine || '');
   const gmailBody = encodeURIComponent(outreach.messageBody || '');
+  const selectedContact = getSelectedOutreachContact();
+  const mailToAddress = selectedContact.email ? encodeURIComponent(selectedContact.email) : '';
+  const gmailTo = selectedContact.email ? `&to=${encodeURIComponent(selectedContact.email)}` : '';
+  const mailtoHref = `mailto:${mailToAddress}?subject=${gmailSubject}&body=${gmailBody}`;
   const pills = [
     outreach.templateLabel ? renderStatusPill(outreach.templateLabel, 'neutral') : '',
     outreach.personaLabel ? renderStatusPill(outreach.personaLabel, 'warm') : '',
@@ -6021,6 +6233,10 @@ function renderGeneratedOutreach(outreach) {
         ${outreach.angleSummary ? `<div class="outreach-brief-block"><span class="outreach-brief-label">Approach</span><p>${escapeHtml(outreach.angleSummary)}</p></div>` : ''}
         ${outreach.sequenceGuidance ? `<div class="outreach-brief-block"><span class="outreach-brief-label">Sequence context</span><p>${escapeHtml(outreach.sequenceGuidance)}</p></div>` : ''}
         ${outreach.companySnippet ? `<div class="outreach-brief-block"><span class="outreach-brief-label">Company context</span><p>${escapeHtml(outreach.companySnippet)}</p></div>` : ''}
+        <div class="button-row outreach-piece-actions">
+          <button class="primary-button" data-action="log-generated-outreach" type="button">Log sent + follow-up</button>
+          <span class="small muted">Use after sending the email draft and LinkedIn message.</span>
+        </div>
       </div>
       <div class="outreach-piece-grid">
         <article class="outreach-piece outreach-piece--primary">
@@ -6032,8 +6248,8 @@ function renderGeneratedOutreach(outreach) {
           <div class="outreach-piece-body">${escapeHtml(outreach.messageBody)}</div>
           <div class="button-row outreach-piece-actions">
             <button class="secondary-button" data-action="copy-generated-outreach" data-kind="email" type="button">Copy email</button>
-            <a class="primary-button" href="mailto:?subject=${gmailSubject}&body=${gmailBody}" target="_blank" rel="noreferrer">Open in mail</a>
-            <a class="secondary-button" href="https://mail.google.com/mail/?view=cm&su=${gmailSubject}&body=${gmailBody}" target="_blank" rel="noreferrer">Draft in Gmail</a>
+            <a class="primary-button" href="${mailtoHref}" target="_blank" rel="noreferrer">Open in mail</a>
+            <a class="secondary-button" href="https://mail.google.com/mail/?view=cm${gmailTo}&su=${gmailSubject}&body=${gmailBody}" target="_blank" rel="noreferrer">Draft in Gmail</a>
           </div>
         </article>
         ${renderOutreachPiece('LinkedIn DM', outreach.linkedinMessage, '<button class="primary-button" data-action="open-generated-linkedin" type="button">Copy & open LinkedIn</button><button class="secondary-button" data-action="copy-generated-outreach" data-kind="linkedin" type="button">Copy DM</button>')}
@@ -6092,9 +6308,10 @@ async function copyGeneratedSubject(index, buttonEl) {
 async function openGeneratedLinkedIn(buttonEl) {
   const outreach = appState.generatedOutreach;
   if (!outreach?.linkedinMessage) return;
+  const selectedContact = getSelectedOutreachContact();
   const originalText = buttonEl.textContent;
   await navigator.clipboard.writeText(outreach.linkedinMessage);
-  window.open('https://www.linkedin.com/messaging/compose', '_blank', 'noopener');
+  window.open(selectedContact.linkedinUrl || 'https://www.linkedin.com/messaging/compose', '_blank', 'noopener');
   buttonEl.textContent = 'Copied & opened';
   setTimeout(() => { buttonEl.textContent = originalText; }, 1800);
 }
@@ -6143,7 +6360,7 @@ async function generateSmartOutreach(accountId, buttonEl, options = {}) {
   try {
     const contactSelect = document.getElementById('outreach-contact-select');
     const selectedOption = contactSelect?.selectedOptions?.[0];
-    const contactName = selectedOption?.value || '';
+    const contactName = selectedOption?.dataset?.name || selectedOption?.value || '';
     const contactTitle = selectedOption?.dataset?.title || '';
 
     const result = await api(`/api/accounts/${accountId}/generate-outreach`, {

--- a/app/app.js
+++ b/app/app.js
@@ -2604,10 +2604,17 @@ function hydrateAdminRuntimePanels(runtime) {
     </div>
   `;
 
-  const jobs = (summary.activeJobs && summary.activeJobs.length ? summary.activeJobs : summary.recentJobs) || [];
-  jobsTarget.innerHTML = jobs.length
-    ? jobs.map((job) => renderBackgroundJobItem(job)).join('')
-    : '<div class="empty-state compact">No background jobs are running right now.</div>';
+  const activeJobs = Array.isArray(summary.activeJobs) ? summary.activeJobs : [];
+  const activeIds = new Set(activeJobs.map((job) => job.id).filter(Boolean));
+  const recentJobs = (Array.isArray(summary.recentJobs) ? summary.recentJobs : []).filter((job) => !activeIds.has(job.id));
+  jobsTarget.innerHTML = `
+    ${activeJobs.length
+      ? activeJobs.map((job) => renderBackgroundJobItem(job)).join('')
+      : '<div class="empty-state compact">No jobs are active right now.</div>'}
+    ${recentJobs.length
+      ? `<div class="inline-header"><strong>Recent jobs</strong><span class="small muted">Completed and failed work</span></div>${recentJobs.map((job) => renderBackgroundJobItem(job)).join('')}`
+      : ''}
+  `;
 }
 
 function scheduleRuntimePoll() {
@@ -3123,6 +3130,7 @@ async function completeSetupWizard() {
         owners: parseSetupOwners(draft.ownersText),
         licenseKey: draft.licenseKey,
         csvContent: appState.setupCsvContent,
+        csvFileName: appState.setupCsvFileName,
       }),
     });
     appState.setupResult = result;
@@ -3153,6 +3161,7 @@ async function completeSetupWizard() {
       showToast('Setup complete.', 'success');
     }
   } catch (error) {
+    appState.setupProgressMessage = error.message || String(error || 'Setup failed.');
     showToast(`Setup failed: ${error.message || error}`, 'error', 8000);
     throw error;
   } finally {
@@ -5144,6 +5153,7 @@ function renderBackgroundJobItem(job) {
     : (job.status === 'failed' ? 'danger' : 'neutral');
 
   const progress = job.status === 'running' ? parseJobProgress(job.progressMessage) : null;
+  const hasRecordsAffected = job.recordsAffected !== undefined && job.recordsAffected !== null && job.recordsAffected !== '';
 
   return `
     <article class="timeline-item job-card job-card--${escapeAttr(job.status || 'queued')}">
@@ -5160,12 +5170,27 @@ function renderBackgroundJobItem(job) {
       ${progress ? `<div class="spark-bar job-progress-bar"><span style="width:${progress.pct}%"></span></div>` : ''}
       <p class="job-card__body">${escapeHtml(job.progressMessage || job.summary || 'Waiting for work to start.')}</p>
       <div class="inline-header">
-        <span class="small muted">${job.startedAt ? `Started ${formatDate(job.startedAt)}` : `Queued ${formatDate(job.queuedAt)}`}${job.recordsAffected ? ` · ${formatNumber(job.recordsAffected)} records` : ''}</span>
+        <span class="small muted">${job.startedAt ? `Started ${formatDate(job.startedAt)}` : `Queued ${formatDate(job.queuedAt)}`}${hasRecordsAffected ? ` · ${formatNumber(job.recordsAffected)} records` : ''}</span>
         ${job.status === 'queued' ? `<button class="ghost-button" data-action="cancel-background-job" data-id="${job.id}">Cancel</button>` : ''}
       </div>
       ${job.errorMessage ? `<p class="small muted">${escapeHtml(job.errorMessage)}</p>` : ''}
     </article>
   `;
+}
+
+function getConnectionsImportActionableCount(stats = {}) {
+  return Number(stats.imported || 0) + Number(stats.updated || 0);
+}
+
+function formatConnectionsImportStats(stats = {}) {
+  return `${formatNumber(stats.imported || 0)} imported, ${formatNumber(stats.updated || 0)} updated, ${formatNumber(stats.skipped || 0)} skipped, ${formatNumber(stats.failed || 0)} failed`;
+}
+
+function getNoConnectionsRowsMessage(stats = {}) {
+  const rowCount = Number(stats.rows || 0);
+  return rowCount
+    ? `No importable LinkedIn connections were found in ${formatNumber(rowCount)} rows. Make sure this is the unzipped Connections.csv file from LinkedIn, not the ZIP or a blank template.`
+    : 'No rows were found. Make sure this is the unzipped Connections.csv file from LinkedIn, not the ZIP or a blank template.';
 }
 
 function renderTimelineItem(item) {
@@ -5611,22 +5636,42 @@ async function runConnectionsCsvImport(dryRun) {
     }
 
     const csvContent = await readTextFile(file);
-    const requestBody = JSON.stringify({ csvContent, fileName: file.name, dryRun, useEmptyState: dryRun });
+    const requestPayload = { csvContent, fileName: file.name, dryRun, useEmptyState: dryRun };
+
+    if (!dryRun) {
+      showToast('Checking LinkedIn CSV before import...', 'info');
+      const preview = await api('/api/import/connections-csv/preview', {
+        method: 'POST',
+        body: JSON.stringify({ csvContent, fileName: file.name, useEmptyState: false }),
+      });
+      const previewStats = preview?.stats || {};
+      if (getConnectionsImportActionableCount(previewStats) <= 0) {
+        const message = getNoConnectionsRowsMessage(previewStats);
+        showToast(message, 'warning', 9000);
+        window.bdLocalApi.setAlert(message, appAlert);
+        return;
+      }
+      window.bdLocalApi.setAlert(`Ready to import ${formatConnectionsImportStats(previewStats)}.`, appAlert);
+    }
 
     const run = await api('/api/import/connections-csv', {
       method: 'POST',
-      body: requestBody,
+      body: JSON.stringify(requestPayload),
     });
     if (!dryRun) {
       showToast('Connections import queued.', 'success');
       const job = await watchBackgroundJob(run.jobId, { label: 'Connections import' });
       const stats = job?.result?.stats || job?.result?.importRun?.stats || {};
-      const message = `Imported ${formatNumber(stats.contacts || 0)} contacts across ${formatNumber(stats.companies || 0)} companies.`;
+      const message = `Connections import complete: ${formatConnectionsImportStats(stats)}. Contacts now ${formatNumber(stats.contacts || 0)} across ${formatNumber(stats.companies || 0)} companies.`;
       window.bdLocalApi.setAlert(message, appAlert);
       return;
     }
     const stats = run?.stats || {};
-    const message = `Dry run succeeded: ${formatNumber(stats.contacts || 0)} contacts across ${formatNumber(stats.companies || 0)} companies.`;
+    const message = `Dry run succeeded: ${formatConnectionsImportStats(stats)}. Contacts would total ${formatNumber(stats.contacts || 0)} across ${formatNumber(stats.companies || 0)} companies.`;
+    window.bdLocalApi.setAlert(message, appAlert);
+  } catch (error) {
+    const message = `Connections import failed: ${error.message || error}`;
+    showToast(message, 'error', 9000);
     window.bdLocalApi.setAlert(message, appAlert);
   } finally {
     if (button) { button.disabled = false; button.textContent = originalLabel; }

--- a/app/app.js
+++ b/app/app.js
@@ -4376,7 +4376,7 @@ async function renderAdminView() {
             <div class="action-card">
               <p class="eyebrow">Full pipeline</p>
               <h4>Run BD Engine</h4>
-              <p class="small muted">Runs connections import, config sync, job fetch, scoring, and Google Sheet export in one pass.</p>
+              <p class="small muted">Runs the legacy Google Sheets pipeline in one pass. Requires a Spreadsheet ID in the Google Sheets card.</p>
               <button class="primary-button" data-action="run-full-engine">Run Full Engine</button>
             </div>
             <div class="action-card">
@@ -5561,6 +5561,13 @@ async function runFullBdEngine() {
   if (button) { button.disabled = true; button.textContent = 'Running full pipeline...'; }
   try {
     const spreadsheetId = getSpreadsheetId();
+    if (!spreadsheetId) {
+      const message = 'Run Full Engine is the legacy Google Sheets pipeline. Enter a Spreadsheet ID in the Google Sheets card before running it.';
+      showToast(message, 'warning', 8000);
+      window.bdLocalApi.setAlert(message, appAlert);
+      document.getElementById('google-sheet-id')?.focus();
+      return;
+    }
     const connectionsCsvPath = getConnectionsCsvPath();
     const accepted = await api('/api/google-sheets/run-engine', {
       method: 'POST',

--- a/app/app.js
+++ b/app/app.js
@@ -52,6 +52,8 @@ const appState = {
   setupCsvFileName: '',
   setupPreview: null,
   setupResult: null,
+  setupImportJobId: '',
+  setupProgressMessage: '',
   setupDraft: {
     workspaceName: '',
     userName: '',
@@ -2706,11 +2708,12 @@ function renderSetupStepContent(stepKey) {
           <button class="secondary-button" type="button" data-action="setup-browse-csv">Choose CSV</button>
         </div>
         ${renderSetupPreview()}
+        ${appState.setupBusy ? renderSetupProgress('Starting setup', appState.setupProgressMessage || 'Saving your setup and preparing the import...') : ''}
         <div class="button-row">
           <button class="secondary-button" type="button" data-action="setup-back">Back</button>
           <button class="secondary-button" type="button" data-action="setup-preview-csv" ${hasCsv && !appState.setupBusy ? '' : 'disabled'}>${appState.setupBusy ? 'Working...' : 'Preview CSV'}</button>
           <button class="ghost-button" type="button" data-action="setup-skip-import" ${appState.setupBusy ? 'disabled' : ''}>Skip import</button>
-          <button class="primary-button" type="button" data-action="setup-complete" ${appState.setupBusy ? 'disabled' : ''}>${appState.setupBusy ? 'Finishing...' : 'Finish setup'}</button>
+          <button class="primary-button" type="button" data-action="setup-complete" ${appState.setupBusy ? 'disabled' : ''}>${appState.setupBusy ? 'Starting...' : 'Finish setup'}</button>
         </div>
       </div>
     `;
@@ -2718,6 +2721,15 @@ function renderSetupStepContent(stepKey) {
 
   const result = appState.setupResult || {};
   const stats = result.stats || {};
+  if (appState.setupBusy && appState.setupImportJobId) {
+    return `
+      <div class="setup-success">
+        ${renderSetupProgress('Importing LinkedIn connections', appState.setupProgressMessage || 'This can take a few minutes for a large LinkedIn export.')}
+        <p class="muted">You can leave this window open. BD Engine is saving contacts, deriving accounts, and avoiding duplicates.</p>
+      </div>
+    `;
+  }
+
   return `
     <div class="setup-success">
       <div class="setup-success-mark" aria-hidden="true">OK</div>
@@ -2731,6 +2743,18 @@ function renderSetupStepContent(stepKey) {
       </div>
       <div class="button-row center">
         <button class="primary-button" type="button" data-action="setup-open-dashboard">Open dashboard</button>
+      </div>
+    </div>
+  `;
+}
+
+function renderSetupProgress(title, message) {
+  return `
+    <div class="setup-progress" role="status" aria-live="polite">
+      <div class="setup-progress-spinner" aria-hidden="true"></div>
+      <div>
+        <strong>${escapeHtml(title)}</strong>
+        <p>${escapeHtml(message || 'Working...')}</p>
       </div>
     </div>
   `;
@@ -2851,6 +2875,9 @@ async function completeSetupWizard() {
   }
 
   appState.setupBusy = true;
+  appState.setupProgressMessage = appState.setupCsvContent
+    ? 'Saving setup and queuing your LinkedIn connections import...'
+    : 'Saving setup...';
   try {
     const result = await api('/api/setup/complete', {
       method: 'POST',
@@ -2867,10 +2894,58 @@ async function completeSetupWizard() {
     appState.setupStatus = result.status;
     appState.setupStep = getSetupSteps().length;
     invalidateAppData();
-    showToast('Setup complete.', 'success');
+
+    if (result.jobId) {
+      appState.setupImportJobId = result.jobId;
+      appState.setupProgressMessage = 'Import queued. Starting the background worker...';
+      await renderSetupWizard();
+      const job = await watchSetupImportJob(result.jobId);
+      const stats = job?.result?.stats || job?.result?.importRun?.stats || {};
+      appState.setupResult = {
+        ...result,
+        stats: {
+          ...stats,
+          imported: stats.imported || 0,
+          updated: stats.updated || 0,
+          skipped: stats.skipped || 0,
+          failed: stats.failed || 0,
+        },
+      };
+      appState.setupProgressMessage = 'Import complete.';
+      showToast('Setup complete. LinkedIn connections imported.', 'success');
+    } else {
+      appState.setupProgressMessage = '';
+      showToast('Setup complete.', 'success');
+    }
+  } catch (error) {
+    showToast(`Setup failed: ${error.message || error}`, 'error', 8000);
+    throw error;
   } finally {
     appState.setupBusy = false;
+    appState.setupImportJobId = '';
     await renderSetupWizard();
+  }
+}
+
+async function watchSetupImportJob(jobId) {
+  while (true) {
+    const job = await api(`/api/background-jobs/${jobId}`, { skipCache: true });
+    const message = job.progressMessage || humanize(job.status || 'running');
+    appState.setupProgressMessage = message;
+    await renderSetupWizard();
+
+    if (job.status === 'completed') {
+      invalidateAppData();
+      return job;
+    }
+    if (job.status === 'failed') {
+      throw new Error(job.errorMessage || 'LinkedIn connections import failed.');
+    }
+    if (job.status === 'cancelled') {
+      throw new Error('LinkedIn connections import was cancelled.');
+    }
+
+    await sleep(1500);
   }
 }
 

--- a/app/app.js
+++ b/app/app.js
@@ -3074,6 +3074,28 @@ async function readTextFile(file) {
   });
 }
 
+function formatFileSize(bytes = 0) {
+  const size = Number(bytes || 0);
+  if (!Number.isFinite(size) || size <= 0) return '0 KB';
+  if (size < 1024 * 1024) return `${Math.max(1, Math.round(size / 1024)).toLocaleString()} KB`;
+  return `${(size / (1024 * 1024)).toFixed(size < 10 * 1024 * 1024 ? 1 : 0)} MB`;
+}
+
+function estimateCsvDataRows(csvContent = '') {
+  const lines = String(csvContent || '').split(/\r\n|\r|\n/).filter((line) => line.trim());
+  const headerIndex = lines.findIndex((line) => /first\s*name/i.test(line) && /(last\s*name|company|position|email|url)/i.test(line));
+  if (headerIndex >= 0) {
+    return Math.max(0, lines.length - headerIndex - 1);
+  }
+  return Math.max(0, lines.length - 1);
+}
+
+function formatCsvUploadSummary(file, csvContent = '') {
+  const rows = estimateCsvDataRows(csvContent);
+  const sizeLabel = formatFileSize(file?.size || csvContent.length || 0);
+  return `${formatNumber(rows)} data row${rows === 1 ? '' : 's'}, ${sizeLabel}`;
+}
+
 async function handleSetupCsvFile(file) {
   if (!file) return;
   persistSetupDraftFromDom();
@@ -5613,7 +5635,7 @@ async function runConnectionsCsvImport(dryRun) {
   const action = dryRun ? 'dry-run-connections-csv' : 'import-connections-csv';
   const button = document.querySelector(`[data-action="${action}"]`);
   const originalLabel = dryRun ? 'Dry run CSV' : 'Import CSV';
-  if (button) { button.disabled = true; button.textContent = dryRun ? 'Dry running...' : 'Importing...'; }
+  if (button) { button.disabled = true; button.textContent = dryRun ? 'Dry running...' : 'Queueing...'; }
 
   try {
     const fileInput = document.getElementById('connections-csv-file');
@@ -5626,13 +5648,16 @@ async function runConnectionsCsvImport(dryRun) {
 
     const csvContent = await readTextFile(file);
     const requestPayload = { csvContent, fileName: file.name, dryRun, useEmptyState: dryRun };
+    const uploadSummary = formatCsvUploadSummary(file, csvContent);
 
     const run = await api('/api/import/connections-csv', {
       method: 'POST',
       body: JSON.stringify(requestPayload),
     });
     if (!dryRun) {
-      showToast('Connections import queued.', 'success');
+      const queuedMessage = `Connections import queued (${uploadSummary}). Large exports can take several minutes; keep this tab open to watch progress.`;
+      showToast(queuedMessage, 'success', 9000);
+      window.bdLocalApi.setAlert(queuedMessage, appAlert);
       const job = await watchBackgroundJob(run.jobId, { label: 'Connections import' });
       const stats = job?.result?.stats || job?.result?.importRun?.stats || {};
       const message = `Connections import complete: ${formatConnectionsImportStats(stats)}. Contacts now ${formatNumber(stats.contacts || 0)} across ${formatNumber(stats.companies || 0)} companies.`;
@@ -5640,7 +5665,7 @@ async function runConnectionsCsvImport(dryRun) {
       return;
     }
     const stats = run?.stats || {};
-    const message = `Dry run succeeded: ${formatConnectionsImportStats(stats)}. Contacts would total ${formatNumber(stats.contacts || 0)} across ${formatNumber(stats.companies || 0)} companies.`;
+    const message = `Dry run succeeded (${uploadSummary}): ${formatConnectionsImportStats(stats)}. Contacts would total ${formatNumber(stats.contacts || 0)} across ${formatNumber(stats.companies || 0)} companies.`;
     window.bdLocalApi.setAlert(message, appAlert);
   } catch (error) {
     const message = `Connections import failed: ${error.message || error}`;

--- a/app/app.js
+++ b/app/app.js
@@ -45,6 +45,20 @@ const appState = {
   alertThresholds: JSON.parse(localStorage.getItem('bd_alert_thresholds') || '{"staleDays":14,"scoreDropMin":10,"hiringSpikeFactor":3,"hiringSpikMinJobs":5,"highScoreNoContacts":80,"highValueStaleMin":70}'),
   bulkLastClickIdx: null,
   duplicateCache: null,
+  setupStatus: null,
+  setupStep: 1,
+  setupBusy: false,
+  setupCsvContent: '',
+  setupCsvFileName: '',
+  setupPreview: null,
+  setupResult: null,
+  setupDraft: {
+    workspaceName: '',
+    userName: '',
+    userEmail: '',
+    ownersText: '',
+    licenseKey: '',
+  },
 };
 
 const viewTitle = document.getElementById('view-title');
@@ -1435,7 +1449,13 @@ async function init() {
   window.bdLocalApi.setAlert('', appAlert);
   renderLoadingState('Dashboard', 'Loading your operating view...');
   try {
+    const setupStatus = await loadSetupStatus(true);
     const initialRoot = getRouteRoot();
+    if (setupStatus?.requiresSetup && initialRoot !== 'setup') {
+      location.hash = '#/setup';
+      await renderRoute();
+      return;
+    }
     if (routeNeedsBootstrapFilters(initialRoot)) {
       await loadBootstrap(true, { includeFilters: true });
       await renderRoute();
@@ -1604,6 +1624,38 @@ function bindEvents() {
     }
 
     const actionName = action.dataset.action;
+    if (actionName === 'setup-browse-csv') {
+      document.getElementById('setup-csv-file')?.click();
+      return;
+    }
+    if (actionName === 'setup-back') {
+      persistSetupDraftFromDom();
+      appState.setupStep = Math.max(1, appState.setupStep - 1);
+      await renderSetupWizard();
+      return;
+    }
+    if (actionName === 'setup-skip-import') {
+      appState.setupCsvContent = '';
+      appState.setupCsvFileName = '';
+      appState.setupPreview = null;
+      await completeSetupWizard();
+      return;
+    }
+    if (actionName === 'setup-preview-csv') {
+      await previewSetupCsv();
+      return;
+    }
+    if (actionName === 'setup-complete') {
+      await completeSetupWizard();
+      return;
+    }
+    if (actionName === 'setup-open-dashboard') {
+      invalidateAppData();
+      await loadBootstrap(true, { includeFilters: true });
+      location.hash = '#/dashboard';
+      await renderRoute();
+      return;
+    }
     if (actionName === 'paginate') {
       const view = action.dataset.view;
       const page = Number(action.dataset.page);
@@ -1873,6 +1925,25 @@ function bindEvents() {
     if (!(form instanceof HTMLFormElement)) return;
     event.preventDefault();
 
+    if (form.id === 'setup-profile-form') {
+      persistSetupDraftFromDom();
+      const { workspaceName: workspace, userName: name, userEmail: email } = appState.setupDraft;
+      if (!workspace.trim() || !name.trim() || !email.trim()) {
+        showToast('Workspace, name, and email are required.', 'warning');
+        return;
+      }
+      appState.setupStep = Math.min(getSetupSteps().length, appState.setupStep + 1);
+      await renderSetupWizard();
+      return;
+    }
+
+    if (form.id === 'setup-team-form' || form.id === 'setup-license-form') {
+      persistSetupDraftFromDom();
+      appState.setupStep = Math.min(getSetupSteps().length, appState.setupStep + 1);
+      await renderSetupWizard();
+      return;
+    }
+
     if (form.id === 'accounts-filter-form') {
       appState.accountQuery = { ...appState.accountQuery, page: 1, ...getFormValues(form) };
       await renderAccountsView();
@@ -2124,6 +2195,18 @@ async function loadBootstrap(force, options = {}) {
 
 async function api(path, options = {}) {
   return window.bdLocalApi.api(appState, path, options);
+}
+
+async function loadSetupStatus(force = false) {
+  if (appState.setupStatus && !force) {
+    return appState.setupStatus;
+  }
+  appState.setupStatus = await api('/api/setup/status', { skipCache: true });
+  if (!appState.setupDraft.workspaceName && appState.setupStatus?.workspace?.name) {
+    const existingName = appState.setupStatus.workspace.name;
+    appState.setupDraft.workspaceName = existingName === 'BD Engine Workspace' ? '' : existingName;
+  }
+  return appState.setupStatus;
 }
 
 function getFormValues(form) {
@@ -2393,6 +2476,30 @@ async function renderRoute() {
   clearRuntimePoll();
   closeMobileNav();
 
+  if (!appState.setupStatus) {
+    await loadSetupStatus(false);
+  }
+
+  if (root === 'setup') {
+    if (appState.setupStatus && !appState.setupStatus.requiresSetup && !appState.setupResult) {
+      location.hash = '#/dashboard';
+      await renderDashboardView();
+      return;
+    }
+    activateNav('');
+    renderBreadcrumbs(null);
+    await renderSetupWizard();
+    return;
+  }
+
+  if (appState.setupStatus?.requiresSetup) {
+    location.hash = '#/setup';
+    activateNav('');
+    renderBreadcrumbs(null);
+    await renderSetupWizard();
+    return;
+  }
+
   if (root === 'accounts' && parts[1]) {
     activateNav('accounts');
     renderBreadcrumbs([
@@ -2437,6 +2544,336 @@ async function renderRoute() {
   renderBreadcrumbs(null);
   await renderDashboardView();
 }
+
+function getSetupSteps() {
+  const steps = [
+    { key: 'profile', label: 'Profile' },
+    { key: 'team', label: 'Team' },
+  ];
+  if (appState.setupStatus?.licensingEnabled) {
+    steps.push({ key: 'license', label: 'License' });
+  }
+  steps.push({ key: 'import', label: 'Import' });
+  steps.push({ key: 'launch', label: 'Launch' });
+  return steps;
+}
+
+function getCurrentSetupStep() {
+  const steps = getSetupSteps();
+  const index = Math.min(Math.max(appState.setupStep, 1), steps.length) - 1;
+  return steps[index] || steps[0];
+}
+
+function persistSetupDraftFromDom() {
+  const workspaceInput = document.getElementById('setup-workspace-name');
+  const userNameInput = document.getElementById('setup-user-name');
+  const userEmailInput = document.getElementById('setup-user-email');
+  const ownersInput = document.getElementById('setup-owners-text');
+  const licenseInput = document.getElementById('setup-license-key');
+  if (workspaceInput) appState.setupDraft.workspaceName = workspaceInput.value.trim();
+  if (userNameInput) appState.setupDraft.userName = userNameInput.value.trim();
+  if (userEmailInput) appState.setupDraft.userEmail = userEmailInput.value.trim();
+  if (ownersInput) appState.setupDraft.ownersText = ownersInput.value;
+  if (licenseInput) appState.setupDraft.licenseKey = licenseInput.value.trim();
+}
+
+function parseSetupOwners(text) {
+  return String(text || '')
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      let displayName = line;
+      let email = '';
+      const emailMatch = line.match(/<([^>]+)>/);
+      if (emailMatch) {
+        email = emailMatch[1].trim();
+        displayName = line.replace(/<[^>]+>/g, '').trim();
+      } else if (line.includes(',')) {
+        const parts = line.split(',');
+        displayName = parts[0].trim();
+        email = parts.slice(1).join(',').trim();
+      }
+      return { displayName, email };
+    });
+}
+
+async function renderSetupWizard() {
+  await loadSetupStatus(false);
+  if (appState.setupResult) {
+    appState.setupStep = getSetupSteps().length;
+  }
+
+  const steps = getSetupSteps();
+  const current = getCurrentSetupStep();
+  const draft = appState.setupDraft;
+  const setupTitle = current.key === 'launch' ? 'Setup complete' : 'First-run setup';
+  setViewTitle(setupTitle);
+  workspaceName.textContent = draft.workspaceName || appState.setupStatus?.workspace?.name || 'BD Engine';
+  window.bdLocalApi.setAlert('', appAlert);
+
+  appRoot.innerHTML = `
+    <section class="setup-shell" aria-labelledby="setup-title">
+      <div class="setup-card">
+        <div class="setup-header">
+          <div>
+            <p class="eyebrow">BD Engine local setup</p>
+            <h2 id="setup-title">${escapeHtml(setupTitle)}</h2>
+            <p class="muted">Create your workspace, bring in your LinkedIn connections, and start from your own data.</p>
+          </div>
+          <ol class="setup-steps" aria-label="Setup progress">
+            ${steps.map((step, index) => `
+              <li class="setup-step ${index + 1 === appState.setupStep ? 'active' : ''} ${index + 1 < appState.setupStep ? 'complete' : ''}">
+                <span>${index + 1}</span>
+                <strong>${escapeHtml(step.label)}</strong>
+              </li>
+            `).join('')}
+          </ol>
+        </div>
+        ${renderSetupStepContent(current.key)}
+      </div>
+    </section>
+  `;
+
+  wireSetupDropZone();
+}
+
+function renderSetupStepContent(stepKey) {
+  const draft = appState.setupDraft;
+  if (stepKey === 'profile') {
+    return `
+      <form id="setup-profile-form" class="setup-form">
+        <div class="setup-grid">
+          <label>Workspace or company name
+            <input id="setup-workspace-name" name="workspaceName" required autocomplete="organization" value="${escapeHtml(draft.workspaceName)}" placeholder="Your company or team" />
+          </label>
+          <label>Your name
+            <input id="setup-user-name" name="userName" required autocomplete="name" value="${escapeHtml(draft.userName)}" placeholder="Full name" />
+          </label>
+          <label>Your email
+            <input id="setup-user-email" name="userEmail" type="email" required autocomplete="email" value="${escapeHtml(draft.userEmail)}" placeholder="you@example.com" />
+          </label>
+        </div>
+        <div class="button-row">
+          <button class="primary-button" type="submit">Continue</button>
+        </div>
+      </form>
+    `;
+  }
+
+  if (stepKey === 'team') {
+    return `
+      <form id="setup-team-form" class="setup-form">
+        <label>Optional team or owner roster
+          <textarea id="setup-owners-text" name="ownersText" rows="7" placeholder="One person per line, for example: Name, email@example.com">${escapeHtml(draft.ownersText)}</textarea>
+        </label>
+        <p class="muted small">Leave this blank if you are the only owner. You can add or edit owners later.</p>
+        <div class="button-row">
+          <button class="secondary-button" type="button" data-action="setup-back">Back</button>
+          <button class="primary-button" type="submit">Continue</button>
+        </div>
+      </form>
+    `;
+  }
+
+  if (stepKey === 'license') {
+    return `
+      <form id="setup-license-form" class="setup-form">
+        <label>License key
+          <input id="setup-license-key" name="licenseKey" autocomplete="off" value="${escapeHtml(draft.licenseKey)}" placeholder="Paste your license key" />
+        </label>
+        <p class="muted small">This step appears only when licensing is enabled for this build.</p>
+        <div class="button-row">
+          <button class="secondary-button" type="button" data-action="setup-back">Back</button>
+          <button class="primary-button" type="submit">Continue</button>
+        </div>
+      </form>
+    `;
+  }
+
+  if (stepKey === 'import') {
+    const hasCsv = Boolean(appState.setupCsvContent);
+    return `
+      <div class="setup-form">
+        <div class="setup-import-copy">
+          <h3>Import LinkedIn Connections.csv</h3>
+          <p class="muted">From LinkedIn, request a copy of your data and choose Connections. When the archive is ready, upload the included <code>Connections.csv</code> file here.</p>
+        </div>
+        <input id="setup-csv-file" class="hidden" type="file" accept=".csv,text/csv" />
+        <div id="setup-drop-zone" class="setup-drop-zone" tabindex="0" role="button" aria-label="Upload LinkedIn Connections CSV">
+          <strong>${hasCsv ? escapeHtml(appState.setupCsvFileName || 'Connections.csv') : 'Drop Connections.csv here'}</strong>
+          <span>${hasCsv ? 'Ready to preview or import.' : 'or choose the file from your computer'}</span>
+          <button class="secondary-button" type="button" data-action="setup-browse-csv">Choose CSV</button>
+        </div>
+        ${renderSetupPreview()}
+        <div class="button-row">
+          <button class="secondary-button" type="button" data-action="setup-back">Back</button>
+          <button class="secondary-button" type="button" data-action="setup-preview-csv" ${hasCsv && !appState.setupBusy ? '' : 'disabled'}>${appState.setupBusy ? 'Working...' : 'Preview CSV'}</button>
+          <button class="ghost-button" type="button" data-action="setup-skip-import" ${appState.setupBusy ? 'disabled' : ''}>Skip import</button>
+          <button class="primary-button" type="button" data-action="setup-complete" ${appState.setupBusy ? 'disabled' : ''}>${appState.setupBusy ? 'Finishing...' : 'Finish setup'}</button>
+        </div>
+      </div>
+    `;
+  }
+
+  const result = appState.setupResult || {};
+  const stats = result.stats || {};
+  return `
+    <div class="setup-success">
+      <div class="setup-success-mark" aria-hidden="true">OK</div>
+      <h3>Your workspace is ready</h3>
+      <p class="muted">BD Engine will now open your dashboard using the local data stored on this computer.</p>
+      <div class="setup-summary-grid">
+        <div><strong>${formatNumber(stats.imported || 0)}</strong><span>Imported</span></div>
+        <div><strong>${formatNumber(stats.updated || 0)}</strong><span>Updated</span></div>
+        <div><strong>${formatNumber(stats.skipped || 0)}</strong><span>Skipped</span></div>
+        <div><strong>${formatNumber(stats.failed || 0)}</strong><span>Failed</span></div>
+      </div>
+      <div class="button-row center">
+        <button class="primary-button" type="button" data-action="setup-open-dashboard">Open dashboard</button>
+      </div>
+    </div>
+  `;
+}
+
+function renderSetupPreview() {
+  const preview = appState.setupPreview;
+  if (!preview) {
+    return `<p class="muted small">Preview checks the file before anything is saved.</p>`;
+  }
+
+  const stats = preview.stats || {};
+  const rows = Array.isArray(preview.preview) ? preview.preview : [];
+  return `
+    <div class="setup-preview">
+      <div class="setup-summary-grid">
+        <div><strong>${formatNumber(stats.imported || 0)}</strong><span>New</span></div>
+        <div><strong>${formatNumber(stats.updated || 0)}</strong><span>Updates</span></div>
+        <div><strong>${formatNumber(stats.skipped || 0)}</strong><span>Skipped</span></div>
+        <div><strong>${formatNumber(stats.failed || 0)}</strong><span>Failed</span></div>
+      </div>
+      <div class="table-scroll">
+        <table class="table setup-preview-table">
+          <thead><tr><th>Action</th><th>Name</th><th>Company</th><th>Title</th><th>Email</th><th>Connected</th></tr></thead>
+          <tbody>
+            ${rows.map(row => `
+              <tr>
+                <td><span class="status-pill">${escapeHtml(row.action || '')}</span></td>
+                <td>${escapeHtml(row.fullName || '')}</td>
+                <td>${escapeHtml(row.companyName || '')}</td>
+                <td>${escapeHtml(row.title || '')}</td>
+                <td>${escapeHtml(row.email || '')}</td>
+                <td>${escapeHtml(row.connectedOn || '')}</td>
+              </tr>
+              ${row.message ? `<tr class="setup-preview-message"><td></td><td colspan="5">${escapeHtml(row.message)}</td></tr>` : ''}
+            `).join('')}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  `;
+}
+
+function wireSetupDropZone() {
+  const zone = document.getElementById('setup-drop-zone');
+  if (!zone) return;
+  zone.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      document.getElementById('setup-csv-file')?.click();
+    }
+  });
+  zone.addEventListener('dragover', (event) => {
+    event.preventDefault();
+    zone.classList.add('dragover');
+  });
+  zone.addEventListener('dragleave', () => zone.classList.remove('dragover'));
+  zone.addEventListener('drop', (event) => {
+    event.preventDefault();
+    zone.classList.remove('dragover');
+    void handleSetupCsvFile(event.dataTransfer?.files?.[0]);
+  });
+}
+
+async function readTextFile(file) {
+  if (!file) return '';
+  if (typeof file.text === 'function') {
+    return await file.text();
+  }
+  return await new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (event) => resolve(event.target.result || '');
+    reader.onerror = () => reject(new Error('Failed to read file.'));
+    reader.readAsText(file);
+  });
+}
+
+async function handleSetupCsvFile(file) {
+  if (!file) return;
+  persistSetupDraftFromDom();
+  if (!file.name.toLowerCase().endsWith('.csv')) {
+    showToast('Please choose the Connections.csv file from LinkedIn.', 'warning');
+  }
+  appState.setupCsvContent = await readTextFile(file);
+  appState.setupCsvFileName = file.name;
+  appState.setupPreview = null;
+  await renderSetupWizard();
+}
+
+async function previewSetupCsv() {
+  persistSetupDraftFromDom();
+  if (!appState.setupCsvContent) {
+    showToast('Choose your LinkedIn Connections.csv file first.', 'warning');
+    return;
+  }
+
+  appState.setupBusy = true;
+  try {
+    appState.setupPreview = await api('/api/import/connections-csv/preview', {
+      method: 'POST',
+      body: JSON.stringify({ csvContent: appState.setupCsvContent, useEmptyState: false }),
+    });
+    showToast('CSV preview is ready.', 'success');
+  } finally {
+    appState.setupBusy = false;
+    await renderSetupWizard();
+  }
+}
+
+async function completeSetupWizard() {
+  persistSetupDraftFromDom();
+  const draft = appState.setupDraft;
+  if (!draft.workspaceName.trim() || !draft.userName.trim() || !draft.userEmail.trim()) {
+    appState.setupStep = 1;
+    await renderSetupWizard();
+    showToast('Workspace, name, and email are required.', 'warning');
+    return;
+  }
+
+  appState.setupBusy = true;
+  try {
+    const result = await api('/api/setup/complete', {
+      method: 'POST',
+      body: JSON.stringify({
+        workspaceName: draft.workspaceName,
+        userName: draft.userName,
+        userEmail: draft.userEmail,
+        owners: parseSetupOwners(draft.ownersText),
+        licenseKey: draft.licenseKey,
+        csvContent: appState.setupCsvContent,
+      }),
+    });
+    appState.setupResult = result;
+    appState.setupStatus = result.status;
+    appState.setupStep = getSetupSteps().length;
+    invalidateAppData();
+    showToast('Setup complete.', 'success');
+  } finally {
+    appState.setupBusy = false;
+    await renderSetupWizard();
+  }
+}
+
 async function renderDashboardView() {
   renderLoadingState('Dashboard', "Building today's hiring radar...");
   setViewTitle('Dashboard');
@@ -4748,6 +5185,10 @@ async function cancelBackgroundJob(jobId) {
 }
 
 document.addEventListener('change', (event) => {
+  if (event.target.id === 'setup-csv-file') {
+    void handleSetupCsvFile(event.target.files?.[0]);
+    return;
+  }
   if (event.target.id === 'bulk-select-all') {
     const checked = event.target.checked;
     document.querySelectorAll('.bulk-checkbox').forEach(cb => { cb.checked = checked; });

--- a/app/app.js
+++ b/app/app.js
@@ -5598,23 +5598,13 @@ async function runConnectionsCsvImport(dryRun) {
     const fileInput = document.getElementById('connections-csv-file');
     const file = fileInput?.files?.[0];
 
-    let requestBody;
-    if (file) {
-      const csvContent = await new Promise((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onload = (e) => resolve(e.target.result);
-        reader.onerror = () => reject(new Error('Failed to read file'));
-        reader.readAsText(file);
-      });
-      requestBody = JSON.stringify({ csvContent, dryRun, useEmptyState: dryRun });
-    } else {
-      const csvPath = getConnectionsCsvPath();
-      if (!csvPath) {
-        showToast('Please select a CSV file using the Browse button.', 'warning');
-        return;
-      }
-      requestBody = JSON.stringify({ csvPath, dryRun, useEmptyState: dryRun });
+    if (!file) {
+      showToast('Choose your LinkedIn Connections.csv file first.', 'warning');
+      return;
     }
+
+    const csvContent = await readTextFile(file);
+    const requestBody = JSON.stringify({ csvContent, fileName: file.name, dryRun, useEmptyState: dryRun });
 
     const run = await api('/api/import/connections-csv', {
       method: 'POST',

--- a/app/app.js
+++ b/app/app.js
@@ -5178,19 +5178,8 @@ function renderBackgroundJobItem(job) {
   `;
 }
 
-function getConnectionsImportActionableCount(stats = {}) {
-  return Number(stats.imported || 0) + Number(stats.updated || 0);
-}
-
 function formatConnectionsImportStats(stats = {}) {
   return `${formatNumber(stats.imported || 0)} imported, ${formatNumber(stats.updated || 0)} updated, ${formatNumber(stats.skipped || 0)} skipped, ${formatNumber(stats.failed || 0)} failed`;
-}
-
-function getNoConnectionsRowsMessage(stats = {}) {
-  const rowCount = Number(stats.rows || 0);
-  return rowCount
-    ? `No importable LinkedIn connections were found in ${formatNumber(rowCount)} rows. Make sure this is the unzipped Connections.csv file from LinkedIn, not the ZIP or a blank template.`
-    : 'No rows were found. Make sure this is the unzipped Connections.csv file from LinkedIn, not the ZIP or a blank template.';
 }
 
 function renderTimelineItem(item) {
@@ -5637,22 +5626,6 @@ async function runConnectionsCsvImport(dryRun) {
 
     const csvContent = await readTextFile(file);
     const requestPayload = { csvContent, fileName: file.name, dryRun, useEmptyState: dryRun };
-
-    if (!dryRun) {
-      showToast('Checking LinkedIn CSV before import...', 'info');
-      const preview = await api('/api/import/connections-csv/preview', {
-        method: 'POST',
-        body: JSON.stringify({ csvContent, fileName: file.name, useEmptyState: false }),
-      });
-      const previewStats = preview?.stats || {};
-      if (getConnectionsImportActionableCount(previewStats) <= 0) {
-        const message = getNoConnectionsRowsMessage(previewStats);
-        showToast(message, 'warning', 9000);
-        window.bdLocalApi.setAlert(message, appAlert);
-        return;
-      }
-      window.bdLocalApi.setAlert(`Ready to import ${formatConnectionsImportStats(previewStats)}.`, appAlert);
-    }
 
     const run = await api('/api/import/connections-csv', {
       method: 'POST',

--- a/app/index.html
+++ b/app/index.html
@@ -8,7 +8,7 @@
   <meta name="theme-color" content="#0f1728">
   <meta name="color-scheme" content="light dark">
   <title>BD Engine | Commercial Revenue Intelligence</title>
-  <link rel="stylesheet" href="/styles.css?v=20260425-v0-polish-setup-bg-6">
+  <link rel="stylesheet" href="/styles.css?v=20260425-v0-polish-setup-bg-7">
   <link rel="manifest" href="/manifest.json">
   <link rel="icon" type="image/svg+xml" href="/icons/icon-192.svg">
   <link rel="apple-touch-icon" href="/icons/icon-192.svg">
@@ -66,8 +66,8 @@
   <div id="cmd-palette-backdrop" class="cmd-palette-backdrop hidden"></div>
   <div id="toast-container" class="toast-container" aria-live="polite"></div>
 
-  <script src="/local-api.js?v=20260425-v0-polish-setup-bg-6"></script>
-  <script src="/app.js?v=20260425-v0-polish-setup-bg-6"></script>
+  <script src="/local-api.js?v=20260425-v0-polish-setup-bg-7"></script>
+  <script src="/app.js?v=20260425-v0-polish-setup-bg-7"></script>
   <script>
     if ('serviceWorker' in navigator) {
       navigator.serviceWorker.register('/sw.js').then((registration) => registration.update()).catch(() => {});

--- a/app/index.html
+++ b/app/index.html
@@ -8,7 +8,7 @@
   <meta name="theme-color" content="#0f1728">
   <meta name="color-scheme" content="light dark">
   <title>BD Engine | Commercial Revenue Intelligence</title>
-  <link rel="stylesheet" href="/styles.css?v=20260425-v0-polish-setup-bg-3">
+  <link rel="stylesheet" href="/styles.css?v=20260425-v0-polish-setup-bg-4">
   <link rel="manifest" href="/manifest.json">
   <link rel="icon" type="image/svg+xml" href="/icons/icon-192.svg">
   <link rel="apple-touch-icon" href="/icons/icon-192.svg">
@@ -66,8 +66,8 @@
   <div id="cmd-palette-backdrop" class="cmd-palette-backdrop hidden"></div>
   <div id="toast-container" class="toast-container" aria-live="polite"></div>
 
-  <script src="/local-api.js?v=20260425-v0-polish-setup-bg-3"></script>
-  <script src="/app.js?v=20260425-v0-polish-setup-bg-3"></script>
+  <script src="/local-api.js?v=20260425-v0-polish-setup-bg-4"></script>
+  <script src="/app.js?v=20260425-v0-polish-setup-bg-4"></script>
   <script>
     if ('serviceWorker' in navigator) {
       navigator.serviceWorker.register('/sw.js').then((registration) => registration.update()).catch(() => {});

--- a/app/index.html
+++ b/app/index.html
@@ -8,7 +8,7 @@
   <meta name="theme-color" content="#0f1728">
   <meta name="color-scheme" content="light dark">
   <title>BD Engine | Commercial Revenue Intelligence</title>
-  <link rel="stylesheet" href="/styles.css">
+  <link rel="stylesheet" href="/styles.css?v=20260425-v0-polish-setup-bg-1">
   <link rel="manifest" href="/manifest.json">
   <link rel="icon" type="image/svg+xml" href="/icons/icon-192.svg">
   <link rel="apple-touch-icon" href="/icons/icon-192.svg">
@@ -23,11 +23,11 @@
         <p class="brand-copy">Commercial BD intelligence, live hiring coverage, and ATS import orchestration in one place.</p>
       </div>
       <nav class="nav" aria-label="Primary">
-        <a href="#/dashboard" data-route="dashboard">Dashboard <span class="nav-shortcut">G D</span></a>
-        <a href="#/accounts" data-route="accounts">Accounts <span class="nav-shortcut">G A</span></a>
-        <a href="#/contacts" data-route="contacts">Contacts <span class="nav-shortcut">G C</span></a>
-        <a href="#/jobs" data-route="jobs">Jobs <span class="nav-shortcut">G J</span></a>
-        <a href="#/admin" data-route="admin">Admin <span class="nav-shortcut">G X</span></a>
+        <a href="#/dashboard" data-route="dashboard"><span class="nav-label">Dashboard</span><span class="nav-shortcut">G D</span></a>
+        <a href="#/accounts" data-route="accounts"><span class="nav-label">Accounts</span><span class="nav-shortcut">G A</span></a>
+        <a href="#/contacts" data-route="contacts"><span class="nav-label">Contacts</span><span class="nav-shortcut">G C</span></a>
+        <a href="#/jobs" data-route="jobs"><span class="nav-label">Jobs</span><span class="nav-shortcut">G J</span></a>
+        <a href="#/admin" data-route="admin"><span class="nav-label">Admin</span><span class="nav-shortcut">G X</span></a>
       </nav>
       <div class="sidebar-footnote">
         <span class="dot"></span>
@@ -66,11 +66,11 @@
   <div id="cmd-palette-backdrop" class="cmd-palette-backdrop hidden"></div>
   <div id="toast-container" class="toast-container" aria-live="polite"></div>
 
-  <script src="/local-api.js"></script>
-  <script src="/app.js"></script>
+  <script src="/local-api.js?v=20260425-v0-polish-setup-bg-1"></script>
+  <script src="/app.js?v=20260425-v0-polish-setup-bg-1"></script>
   <script>
     if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register('/sw.js').catch(() => {});
+      navigator.serviceWorker.register('/sw.js').then((registration) => registration.update()).catch(() => {});
     }
   </script>
 </body>

--- a/app/index.html
+++ b/app/index.html
@@ -8,7 +8,7 @@
   <meta name="theme-color" content="#0f1728">
   <meta name="color-scheme" content="light dark">
   <title>BD Engine | Commercial Revenue Intelligence</title>
-  <link rel="stylesheet" href="/styles.css?v=20260425-v0-polish-setup-bg-5">
+  <link rel="stylesheet" href="/styles.css?v=20260425-v0-polish-setup-bg-6">
   <link rel="manifest" href="/manifest.json">
   <link rel="icon" type="image/svg+xml" href="/icons/icon-192.svg">
   <link rel="apple-touch-icon" href="/icons/icon-192.svg">
@@ -66,8 +66,8 @@
   <div id="cmd-palette-backdrop" class="cmd-palette-backdrop hidden"></div>
   <div id="toast-container" class="toast-container" aria-live="polite"></div>
 
-  <script src="/local-api.js?v=20260425-v0-polish-setup-bg-5"></script>
-  <script src="/app.js?v=20260425-v0-polish-setup-bg-5"></script>
+  <script src="/local-api.js?v=20260425-v0-polish-setup-bg-6"></script>
+  <script src="/app.js?v=20260425-v0-polish-setup-bg-6"></script>
   <script>
     if ('serviceWorker' in navigator) {
       navigator.serviceWorker.register('/sw.js').then((registration) => registration.update()).catch(() => {});

--- a/app/index.html
+++ b/app/index.html
@@ -8,7 +8,7 @@
   <meta name="theme-color" content="#0f1728">
   <meta name="color-scheme" content="light dark">
   <title>BD Engine | Commercial Revenue Intelligence</title>
-  <link rel="stylesheet" href="/styles.css?v=20260425-v0-polish-setup-bg-2">
+  <link rel="stylesheet" href="/styles.css?v=20260425-v0-polish-setup-bg-3">
   <link rel="manifest" href="/manifest.json">
   <link rel="icon" type="image/svg+xml" href="/icons/icon-192.svg">
   <link rel="apple-touch-icon" href="/icons/icon-192.svg">
@@ -66,8 +66,8 @@
   <div id="cmd-palette-backdrop" class="cmd-palette-backdrop hidden"></div>
   <div id="toast-container" class="toast-container" aria-live="polite"></div>
 
-  <script src="/local-api.js?v=20260425-v0-polish-setup-bg-2"></script>
-  <script src="/app.js?v=20260425-v0-polish-setup-bg-2"></script>
+  <script src="/local-api.js?v=20260425-v0-polish-setup-bg-3"></script>
+  <script src="/app.js?v=20260425-v0-polish-setup-bg-3"></script>
   <script>
     if ('serviceWorker' in navigator) {
       navigator.serviceWorker.register('/sw.js').then((registration) => registration.update()).catch(() => {});

--- a/app/index.html
+++ b/app/index.html
@@ -8,7 +8,7 @@
   <meta name="theme-color" content="#0f1728">
   <meta name="color-scheme" content="light dark">
   <title>BD Engine | Commercial Revenue Intelligence</title>
-  <link rel="stylesheet" href="/styles.css?v=20260425-v0-polish-setup-bg-1">
+  <link rel="stylesheet" href="/styles.css?v=20260425-v0-polish-setup-bg-2">
   <link rel="manifest" href="/manifest.json">
   <link rel="icon" type="image/svg+xml" href="/icons/icon-192.svg">
   <link rel="apple-touch-icon" href="/icons/icon-192.svg">
@@ -66,8 +66,8 @@
   <div id="cmd-palette-backdrop" class="cmd-palette-backdrop hidden"></div>
   <div id="toast-container" class="toast-container" aria-live="polite"></div>
 
-  <script src="/local-api.js?v=20260425-v0-polish-setup-bg-1"></script>
-  <script src="/app.js?v=20260425-v0-polish-setup-bg-1"></script>
+  <script src="/local-api.js?v=20260425-v0-polish-setup-bg-2"></script>
+  <script src="/app.js?v=20260425-v0-polish-setup-bg-2"></script>
   <script>
     if ('serviceWorker' in navigator) {
       navigator.serviceWorker.register('/sw.js').then((registration) => registration.update()).catch(() => {});

--- a/app/index.html
+++ b/app/index.html
@@ -8,7 +8,7 @@
   <meta name="theme-color" content="#0f1728">
   <meta name="color-scheme" content="light dark">
   <title>BD Engine | Commercial Revenue Intelligence</title>
-  <link rel="stylesheet" href="/styles.css?v=20260425-v0-polish-setup-bg-4">
+  <link rel="stylesheet" href="/styles.css?v=20260425-v0-polish-setup-bg-5">
   <link rel="manifest" href="/manifest.json">
   <link rel="icon" type="image/svg+xml" href="/icons/icon-192.svg">
   <link rel="apple-touch-icon" href="/icons/icon-192.svg">
@@ -66,8 +66,8 @@
   <div id="cmd-palette-backdrop" class="cmd-palette-backdrop hidden"></div>
   <div id="toast-container" class="toast-container" aria-live="polite"></div>
 
-  <script src="/local-api.js?v=20260425-v0-polish-setup-bg-4"></script>
-  <script src="/app.js?v=20260425-v0-polish-setup-bg-4"></script>
+  <script src="/local-api.js?v=20260425-v0-polish-setup-bg-5"></script>
+  <script src="/app.js?v=20260425-v0-polish-setup-bg-5"></script>
   <script>
     if ('serviceWorker' in navigator) {
       navigator.serviceWorker.register('/sw.js').then((registration) => registration.update()).catch(() => {});

--- a/app/local-api.js
+++ b/app/local-api.js
@@ -22,6 +22,17 @@
     responseCache.clear();
   }
 
+  function getNetworkErrorMessage(path, error) {
+    const rawMessage = error && error.message ? String(error.message) : String(error || '');
+    const looksLikeFetchFailure = /failed to fetch|networkerror|load failed|cancelled|aborted/i.test(rawMessage);
+    if (!looksLikeFetchFailure) {
+      return rawMessage || 'Request failed before BD Engine could respond.';
+    }
+
+    const target = String(path || '').startsWith('/api/') ? 'BD Engine local server' : 'BD Engine';
+    return `${target} did not respond. Refresh the browser tab, or launch BD Engine again from the desktop shortcut if the server is not running.`;
+  }
+
   async function remoteApi(path, options = {}) {
     const method = getMethod(options);
     const useCache = method === 'GET' && !options.skipCache;
@@ -38,11 +49,16 @@
     }
 
     const fetchPromise = (async () => {
-      const response = await fetch(path, {
-        headers: { 'Content-Type': 'application/json' },
-        cache: 'no-store',
-        ...options,
-      });
+      let response;
+      try {
+        response = await fetch(path, {
+          headers: { 'Content-Type': 'application/json' },
+          cache: 'no-store',
+          ...options,
+        });
+      } catch (error) {
+        throw new Error(getNetworkErrorMessage(path, error));
+      }
 
       if (!response.ok) {
         let message = `Request failed: ${response.status}`;

--- a/app/styles.css
+++ b/app/styles.css
@@ -3287,6 +3287,34 @@ a {
   font-size: 0.82rem;
   background: var(--surface-muted);
 }
+.setup-progress {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 16px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--accent-soft);
+  text-align: left;
+}
+.setup-progress p {
+  margin: 3px 0 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+.setup-progress-spinner {
+  width: 28px;
+  height: 28px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  border: 3px solid var(--line);
+  border-top-color: var(--accent);
+  animation: setup-spin 0.8s linear infinite;
+}
+@keyframes setup-spin {
+  to { transform: rotate(360deg); }
+}
 .setup-success {
   text-align: center;
   display: grid;

--- a/app/styles.css
+++ b/app/styles.css
@@ -3143,6 +3143,179 @@ a {
 /* ── Alert Thresholds ── */
 .alert-thresholds-panel .detail-form { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 10px; }
 
+/* ── First-run setup ── */
+.setup-shell {
+  max-width: 1040px;
+  margin: 0 auto;
+  padding: 10px 0 40px;
+}
+.setup-card {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  padding: 24px;
+}
+.setup-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 0.8fr);
+  gap: 22px;
+  align-items: start;
+  margin-bottom: 24px;
+}
+.setup-header h2 { margin: 4px 0 6px; font-size: 1.55rem; }
+.setup-steps {
+  list-style: none;
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+}
+.setup-step {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 9px 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  color: var(--muted);
+  background: var(--surface-muted);
+}
+.setup-step span {
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: var(--bg);
+  color: var(--text-muted);
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+.setup-step.active {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  color: var(--text);
+}
+.setup-step.complete span {
+  background: var(--success);
+  color: #fff;
+}
+.setup-form {
+  display: grid;
+  gap: 18px;
+}
+.setup-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 14px;
+}
+.setup-form label {
+  display: grid;
+  gap: 7px;
+  font-weight: 700;
+  color: var(--text);
+}
+.setup-form input,
+.setup-form textarea {
+  width: 100%;
+  min-width: 0;
+}
+.setup-import-copy h3,
+.setup-success h3 {
+  margin: 0 0 6px;
+  font-size: 1.15rem;
+}
+.setup-drop-zone {
+  min-height: 170px;
+  border: 1px dashed var(--line-strong, var(--line));
+  border-radius: var(--radius-md);
+  display: grid;
+  place-items: center;
+  gap: 8px;
+  padding: 22px;
+  text-align: center;
+  background: var(--surface-muted);
+  transition: border-color 0.16s ease, background 0.16s ease;
+}
+.setup-drop-zone strong {
+  font-size: 1.05rem;
+}
+.setup-drop-zone span {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+.setup-drop-zone.dragover,
+.setup-drop-zone:focus {
+  outline: none;
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+.setup-preview {
+  display: grid;
+  gap: 14px;
+}
+.setup-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(100px, 1fr));
+  gap: 10px;
+}
+.setup-summary-grid div {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  padding: 12px;
+  background: var(--surface-muted);
+}
+.setup-summary-grid strong {
+  display: block;
+  font-size: 1.35rem;
+  line-height: 1;
+}
+.setup-summary-grid span {
+  color: var(--muted);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0;
+}
+.setup-preview-table td,
+.setup-preview-table th {
+  white-space: nowrap;
+}
+.setup-preview-message td {
+  color: var(--muted);
+  font-size: 0.82rem;
+  background: var(--surface-muted);
+}
+.setup-success {
+  text-align: center;
+  display: grid;
+  justify-items: center;
+  gap: 16px;
+  padding: 20px 0 8px;
+}
+.setup-success-mark {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--success);
+  color: #fff;
+  font-weight: 800;
+}
+.button-row.center { justify-content: center; }
+@media (max-width: 820px) {
+  .setup-card { padding: 18px; }
+  .setup-header { grid-template-columns: 1fr; }
+  .setup-summary-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+@media (max-width: 520px) {
+  .setup-summary-grid { grid-template-columns: 1fr; }
+  .setup-drop-zone { min-height: 150px; }
+}
+
 /* ── Print styles ── */
 @media print {
   .sidebar, .topbar, .mobile-nav-backdrop, .toast-container,

--- a/app/styles.css
+++ b/app/styles.css
@@ -1,18 +1,18 @@
 :root {
-  --bg: #f3f6fb;
-  --bg-soft: #eef2f8;
-  --surface: rgba(255, 255, 255, 0.94);
+  --bg: #f5f7fb;
+  --bg-soft: #eef3f7;
+  --surface: rgba(255, 255, 255, 0.96);
   --surface-strong: #ffffff;
-  --surface-muted: #f7f9fc;
+  --surface-muted: #f6f8fb;
   --surface-ink: #0f1728;
   --ink: #162033;
   --muted: #617089;
   --text: #162033;
   --text-muted: #617089;
-  --line: rgba(22, 32, 51, 0.08);
-  --border: rgba(22, 32, 51, 0.08);
-  --line-strong: rgba(22, 32, 51, 0.14);
-  --shadow-md: 0 16px 32px rgba(15, 23, 42, 0.07);
+  --line: rgba(22, 32, 51, 0.1);
+  --border: rgba(22, 32, 51, 0.1);
+  --line-strong: rgba(22, 32, 51, 0.16);
+  --shadow-md: 0 10px 24px rgba(15, 23, 42, 0.06);
   --accent: #1f63d8;
   --accent-soft: rgba(31, 99, 216, 0.12);
   --success: #14805d;
@@ -21,12 +21,12 @@
   --warning-soft: rgba(169, 111, 23, 0.14);
   --danger: #c2544b;
   --danger-soft: rgba(194, 84, 75, 0.12);
-  --shadow-lg: 0 22px 46px rgba(15, 23, 42, 0.08);
-  --shadow-sm: 0 10px 24px rgba(15, 23, 42, 0.05);
-  --radius-xl: 28px;
-  --radius-lg: 20px;
-  --radius-md: 14px;
-  --radius-sm: 10px;
+  --shadow-lg: 0 18px 38px rgba(15, 23, 42, 0.08);
+  --shadow-sm: 0 6px 16px rgba(15, 23, 42, 0.04);
+  --radius-xl: 8px;
+  --radius-lg: 8px;
+  --radius-md: 8px;
+  --radius-sm: 6px;
 }
 
 * {
@@ -42,11 +42,7 @@ body {
 body {
   font-family: "Aptos", "Segoe UI Variable", "Segoe UI", sans-serif;
   color: var(--ink);
-  background:
-    radial-gradient(circle at top left, rgba(31, 99, 216, 0.1), transparent 26%),
-    radial-gradient(circle at 85% 0%, rgba(20, 128, 93, 0.09), transparent 22%),
-    radial-gradient(circle at 50% 0%, rgba(169, 111, 23, 0.05), transparent 18%),
-    linear-gradient(180deg, #f6f8fc 0%, #eef2f8 100%);
+  background: linear-gradient(180deg, #f8fafc 0%, #eef3f7 100%);
   line-height: 1.45;
   -webkit-font-smoothing: antialiased;
   text-rendering: geometricPrecision;
@@ -54,21 +50,14 @@ body {
 }
 
 body::before {
-  content: "";
-  position: fixed;
-  inset: 0;
-  pointer-events: none;
-  background:
-    radial-gradient(circle at 15% 0%, rgba(31, 99, 216, 0.06), transparent 18%),
-    radial-gradient(circle at 82% 8%, rgba(20, 128, 93, 0.05), transparent 16%);
-  opacity: 0.85;
+  content: none;
 }
 
 .page-noise {
   position: fixed;
   inset: 0;
   pointer-events: none;
-  opacity: 0.22;
+  opacity: 0.08;
   background-image:
     linear-gradient(rgba(22, 32, 51, 0.03) 1px, transparent 1px),
     linear-gradient(90deg, rgba(22, 32, 51, 0.024) 1px, transparent 1px);
@@ -83,7 +72,7 @@ h4 {
   margin: 0;
   font-family: "Aptos Display", "Aptos", "Segoe UI Variable", sans-serif;
   font-weight: 700;
-  letter-spacing: -0.03em;
+  letter-spacing: 0;
 }
 
 p {
@@ -109,19 +98,21 @@ a {
 .shell {
   position: relative;
   display: grid;
-  grid-template-columns: 288px minmax(0, 1fr);
-  gap: 24px;
-  padding: 24px;
+  grid-template-columns: 256px minmax(0, 1fr);
+  gap: 20px;
+  width: min(100%, 1760px);
+  margin: 0 auto;
+  padding: 18px;
 }
 
 .sidebar {
   position: sticky;
-  top: 24px;
+  top: 18px;
   align-self: start;
   display: flex;
   flex-direction: column;
   gap: 18px;
-  max-height: calc(100vh - 48px);
+  max-height: calc(100vh - 36px);
 }
 
 .main {
@@ -199,7 +190,7 @@ a {
 
 .eyebrow {
   text-transform: uppercase;
-  letter-spacing: 0.14em;
+  letter-spacing: 0;
   font-size: 0.72rem;
   font-weight: 700;
   color: rgba(97, 112, 137, 0.92);
@@ -289,7 +280,7 @@ a {
 .search-shell span {
   font-size: 0.72rem;
   text-transform: uppercase;
-  letter-spacing: 0.12em;
+  letter-spacing: 0;
   color: var(--muted);
 }
 
@@ -464,7 +455,7 @@ a {
 .story-card__label {
   font-size: 0.72rem;
   text-transform: uppercase;
-  letter-spacing: 0.12em;
+  letter-spacing: 0;
   color: var(--muted);
   font-weight: 700;
 }
@@ -525,7 +516,7 @@ a {
 .trust-card__eyebrow {
   font-size: 0.72rem;
   text-transform: uppercase;
-  letter-spacing: 0.12em;
+  letter-spacing: 0;
   color: var(--muted);
   font-weight: 700;
 }
@@ -570,7 +561,7 @@ a {
 .signal-chip__label {
   font-size: 0.72rem;
   text-transform: uppercase;
-  letter-spacing: 0.12em;
+  letter-spacing: 0;
   color: var(--muted);
   font-weight: 700;
 }
@@ -705,6 +696,62 @@ a {
   font-size: 1.08rem;
 }
 
+.ingestion-health {
+  display: grid;
+  gap: 14px;
+  padding: 16px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: rgba(247, 249, 252, 0.92);
+}
+
+.ingestion-health__head {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.ingestion-health__head strong {
+  display: block;
+  margin-top: 3px;
+  color: var(--ink);
+}
+
+.ingestion-health__grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.ingestion-health__metric {
+  display: grid;
+  gap: 5px;
+  min-width: 0;
+  padding: 12px;
+  border: 1px solid rgba(97, 112, 137, 0.18);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.78);
+}
+
+.ingestion-health__metric strong {
+  overflow: hidden;
+  color: var(--ink);
+  font-size: 1.06rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ingestion-health__metric .small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ingestion-health__bar {
+  height: 7px;
+}
+
 .inline-split {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -770,7 +817,7 @@ a {
   color: var(--muted);
   font-size: 0.78rem;
   text-transform: uppercase;
-  letter-spacing: 0.12em;
+  letter-spacing: 0;
   font-weight: 700;
 }
 
@@ -872,7 +919,7 @@ a {
   color: var(--muted);
   font-size: 0.74rem;
   text-transform: uppercase;
-  letter-spacing: 0.12em;
+  letter-spacing: 0;
   font-weight: 700;
 }
 
@@ -988,7 +1035,7 @@ a {
 .inline-field label {
   font-size: 0.72rem;
   text-transform: uppercase;
-  letter-spacing: 0.12em;
+  letter-spacing: 0;
   color: var(--muted);
   font-weight: 700;
 }
@@ -1091,7 +1138,7 @@ a {
   color: var(--surface-ink);
   font-size: 0.75rem;
   font-weight: 700;
-  letter-spacing: 0.01em;
+  letter-spacing: 0;
   cursor: pointer;
   transition: border-color 140ms ease, background 140ms ease, color 140ms ease, transform 140ms ease;
 }
@@ -1613,6 +1660,10 @@ a {
     flex-direction: column;
   }
 
+  .ingestion-health__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .trust-strip {
     grid-template-columns: 1fr;
   }
@@ -1648,6 +1699,10 @@ a {
   .table th,
   .table td {
     padding: 12px 10px;
+  }
+
+  .ingestion-health__grid {
+    grid-template-columns: 1fr;
   }
 
   .hero-card,
@@ -2014,7 +2069,7 @@ a {
 .outreach-brief-label {
   font-size: 0.74rem;
   font-weight: 700;
-  letter-spacing: 0.08em;
+  letter-spacing: 0;
   text-transform: uppercase;
   color: var(--muted);
 }
@@ -2347,6 +2402,772 @@ a {
 }
 
 /* ══════════════════════════════════════════════════
+   UX refresh: quieter operational interface
+   ══════════════════════════════════════════════════ */
+.brand-card,
+.sidebar-footnote,
+.topbar,
+.hero-card,
+.metric-card,
+.table-card,
+.detail-card,
+.list-card,
+.chart-card,
+.form-card,
+.action-card,
+.search-results {
+  border-color: var(--line);
+  backdrop-filter: none;
+}
+
+.brand-card {
+  padding: 20px;
+  background: linear-gradient(180deg, #13213a 0%, #0f1728 100%);
+  box-shadow: var(--shadow-md);
+}
+
+.brand-card::after,
+.hero-card::after,
+.hero-card--dashboard::before,
+.hero-card--compact::before {
+  content: none;
+}
+
+.brand-card h1 {
+  font-size: 1.56rem;
+}
+
+.brand-copy {
+  font-size: 0.9rem;
+  line-height: 1.55;
+}
+
+.nav {
+  gap: 6px;
+}
+
+.nav a {
+  position: relative;
+  gap: 10px;
+  min-height: 42px;
+  padding: 10px 12px;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--muted);
+  font-weight: 700;
+}
+
+.nav a::before {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+  background: rgba(97, 112, 137, 0.1);
+  color: var(--muted);
+  font-size: 0.82rem;
+  line-height: 1;
+}
+
+.nav a[data-route="dashboard"]::before { content: "D"; }
+.nav a[data-route="accounts"]::before { content: "A"; }
+.nav a[data-route="contacts"]::before { content: "C"; }
+.nav a[data-route="jobs"]::before { content: "J"; }
+.nav a[data-route="admin"]::before { content: "O"; }
+
+.nav a:hover,
+.nav a.active {
+  transform: none;
+  background: var(--surface-strong);
+  border-color: var(--line-strong);
+  color: var(--surface-ink);
+  box-shadow: var(--shadow-sm);
+}
+
+.nav a.active::before {
+  background: var(--accent);
+  color: #ffffff;
+}
+
+.nav-shortcut {
+  margin-left: auto;
+  color: var(--muted);
+  opacity: 0.7;
+}
+
+.topbar {
+  position: sticky;
+  top: 18px;
+  z-index: 20;
+  padding: 14px 16px;
+  margin-bottom: 14px;
+  background: rgba(255, 255, 255, 0.94);
+}
+
+.topbar h2 {
+  font-size: 1.45rem;
+}
+
+.topbar-tools {
+  gap: 8px;
+}
+
+.search-shell {
+  min-width: min(32vw, 340px);
+  padding: 9px 11px;
+  background: #ffffff;
+}
+
+.search-shell span,
+.eyebrow,
+.metric-label,
+.table th,
+.field label,
+.inline-field label,
+.story-card__label,
+.signal-chip__label,
+.trust-card__eyebrow {
+  letter-spacing: 0;
+}
+
+.hero-card,
+.table-card,
+.detail-card,
+.list-card,
+.chart-card,
+.form-card {
+  padding: 18px;
+  background: var(--surface-strong);
+  box-shadow: var(--shadow-sm);
+}
+
+.hero-card {
+  animation: rise-in 260ms ease-out both;
+}
+
+.hero-card--dashboard {
+  gap: 14px;
+}
+
+.hero-layout {
+  grid-template-columns: minmax(0, 1.35fr) minmax(240px, 0.7fr);
+  gap: 18px;
+}
+
+.hero-copy {
+  gap: 9px;
+}
+
+.hero-copy h3 {
+  max-width: 22ch;
+  font-size: 1.7rem;
+  line-height: 1.08;
+}
+
+.subtitle {
+  max-width: 64ch;
+  line-height: 1.55;
+}
+
+.story-strip,
+.hero-signal-strip,
+.spotlight-metrics {
+  gap: 8px;
+}
+
+.story-card,
+.trust-card,
+.signal-chip,
+.kpi-tile,
+.metric-card,
+.action-card,
+.timeline-item,
+.job-card,
+.status-item,
+.empty-state,
+.field,
+.inline-field,
+.definition-grid > div {
+  border-radius: var(--radius-md);
+}
+
+.story-card,
+.trust-card,
+.signal-chip,
+.kpi-tile {
+  box-shadow: none;
+  background: var(--surface-muted);
+  border-color: var(--line);
+}
+
+.story-card {
+  flex-basis: 210px;
+  padding: 12px;
+}
+
+.story-card::after {
+  height: 2px;
+}
+
+.story-card strong,
+.trust-card strong {
+  font-size: 0.98rem;
+}
+
+.story-card p,
+.trust-card p {
+  font-size: 0.86rem;
+}
+
+.trust-strip {
+  gap: 10px;
+}
+
+.trust-card {
+  padding: 14px;
+}
+
+.admin-command-strip {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap: 10px;
+  margin: 12px 0;
+}
+
+.command-card {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  min-height: 96px;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--surface-strong);
+  box-shadow: var(--shadow-sm);
+}
+
+.command-card__step {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 8px;
+  background: var(--surface-muted);
+  color: var(--text-muted);
+  font-size: 0.82rem;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.command-card__copy {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
+.command-card__copy strong,
+.command-card__copy span,
+.command-card__copy small {
+  overflow-wrap: anywhere;
+}
+
+.command-card__copy strong {
+  color: var(--text);
+  font-size: 0.96rem;
+}
+
+.command-card__copy span {
+  color: var(--text);
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.command-card__copy small {
+  color: var(--muted);
+  font-size: 0.78rem;
+  line-height: 1.35;
+}
+
+.command-card--accent .command-card__step {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.command-card--success .command-card__step {
+  background: var(--success-soft);
+  color: var(--success);
+}
+
+.command-card--warning .command-card__step {
+  background: var(--warning-soft);
+  color: var(--warning);
+}
+
+.workflow-strip {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 10px;
+  margin: 12px 0;
+}
+
+.workflow-card {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  min-height: 88px;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--surface-strong);
+  box-shadow: var(--shadow-sm);
+}
+
+.workflow-card__step {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  background: var(--surface-muted);
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  font-weight: 800;
+}
+
+.workflow-card--primary .workflow-card__step {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.workflow-card__copy {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
+.workflow-card__copy strong,
+.workflow-card__copy span {
+  overflow-wrap: anywhere;
+}
+
+.workflow-card__copy strong {
+  color: var(--text);
+  font-size: 0.96rem;
+}
+
+.workflow-card__copy span {
+  color: var(--muted);
+  font-size: 0.84rem;
+}
+
+.account-preset-strip {
+  display: grid;
+  grid-template-columns: minmax(180px, 0.26fr) minmax(0, 1fr);
+  gap: 12px;
+  align-items: stretch;
+  margin: 12px 0 14px;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--surface-strong);
+  box-shadow: var(--shadow-sm);
+}
+
+.preset-strip-copy {
+  display: grid;
+  align-content: center;
+  gap: 4px;
+}
+
+.preset-strip-copy strong {
+  color: var(--text);
+  line-height: 1.25;
+}
+
+.preset-button-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 8px;
+}
+
+.preset-button {
+  display: grid;
+  gap: 4px;
+  min-height: 66px;
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--surface-muted);
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+}
+
+.preset-button:hover,
+.preset-button.active {
+  border-color: var(--line-strong);
+  background: #ffffff;
+  box-shadow: var(--shadow-sm);
+}
+
+.preset-button.active {
+  outline: 2px solid rgba(31, 99, 216, 0.18);
+}
+
+.preset-button span {
+  font-weight: 800;
+  line-height: 1.2;
+}
+
+.preset-button small {
+  color: var(--muted);
+  font-size: 0.78rem;
+  line-height: 1.35;
+}
+
+.active-filter-strip {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 7px;
+  margin: 10px 0 12px;
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+.active-filter-strip--empty {
+  padding: 8px 10px;
+  border: 1px dashed var(--line);
+  border-radius: var(--radius-md);
+  background: var(--surface-muted);
+}
+
+.filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  max-width: 260px;
+  padding: 5px 9px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--surface-muted);
+  color: var(--text);
+  line-height: 1.25;
+}
+
+.filter-chip strong {
+  color: var(--muted);
+}
+
+.signal-chip {
+  min-width: 110px;
+  padding: 10px 12px;
+}
+
+.signal-chip strong {
+  font-size: 1rem;
+}
+
+.metrics-grid {
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+.metric-card {
+  min-height: 116px;
+  padding: 16px;
+  border-color: var(--line);
+}
+
+.metric-value {
+  font-size: 1.8rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.kpi-ribbon {
+  gap: 8px;
+}
+
+.headline-metrics {
+  justify-content: flex-start;
+}
+
+.kpi-tile {
+  min-width: 118px;
+  padding: 10px 12px;
+  border-color: var(--line);
+}
+
+.kpi-tile strong {
+  font-size: 1.08rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.table-scroll {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+}
+
+.table {
+  font-size: 0.92rem;
+}
+
+.table th {
+  background: var(--surface-muted);
+  color: var(--text-muted);
+  font-size: 0.72rem;
+}
+
+.table th,
+.table td {
+  padding: 11px 12px;
+}
+
+.table tbody tr:nth-child(even) td {
+  background: rgba(97, 112, 137, 0.025);
+}
+
+.table tr:hover td {
+  background: rgba(31, 99, 216, 0.055);
+}
+
+.table-card:hover,
+.detail-card:hover,
+.list-card:hover,
+.chart-card:hover,
+.form-card:hover,
+.metric-card:hover,
+.action-card:hover,
+.trust-card:hover,
+.story-card:hover {
+  transform: none;
+  box-shadow: var(--shadow-md);
+}
+
+.panel-header {
+  align-items: center;
+}
+
+.panel-header-actions {
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.filter-grid {
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  align-items: stretch;
+}
+
+.filter-grid--compact,
+.filter-grid--dense {
+  grid-template-columns: repeat(auto-fit, minmax(168px, 1fr));
+}
+
+.field,
+.inline-field {
+  padding: 10px 12px;
+  background: var(--surface-muted);
+}
+
+.field--action {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: end;
+  gap: 8px;
+}
+
+.field input,
+.field select,
+.field textarea,
+.inline-field input,
+.inline-field select,
+.inline-field textarea,
+.compact-input,
+.compact-select,
+.inline-select {
+  min-height: 36px;
+}
+
+.ghost-button,
+.primary-button,
+.secondary-button,
+.tag-button,
+.view-toggle-btn,
+.filter-toggle-btn,
+.micro-button {
+  border-radius: var(--radius-md);
+  font-weight: 700;
+}
+
+.ghost-button,
+.primary-button,
+.secondary-button,
+.tag-button {
+  min-height: 38px;
+  padding: 8px 13px;
+}
+
+.primary-button {
+  box-shadow: 0 8px 16px rgba(31, 99, 216, 0.16);
+}
+
+.ghost-button {
+  background: var(--surface-muted);
+  border-color: var(--line);
+}
+
+.ghost-button:hover,
+.primary-button:hover,
+.secondary-button:hover,
+.tag-button:hover,
+.micro-button:hover {
+  transform: none;
+}
+
+:focus-visible {
+  outline: 3px solid rgba(31, 99, 216, 0.24);
+  outline-offset: 2px;
+}
+
+.status-pill,
+.badge,
+.table-meta,
+.spark-bar,
+.job-progress-bar,
+.skeleton-pill,
+.skeleton-line,
+.dq-badge,
+.dq-gap-chip {
+  border-radius: 999px;
+}
+
+.timeline {
+  gap: 8px;
+}
+
+.timeline-item,
+.job-card,
+.empty-state {
+  background: var(--surface-muted);
+}
+
+.timeline-item p {
+  line-height: 1.5;
+}
+
+.dashboard-grid,
+.detail-grid {
+  gap: 14px;
+}
+
+.playbook-grid,
+.charts-grid,
+.velocity-stats,
+.definition-grid {
+  gap: 10px;
+}
+
+.spotlight-quote {
+  border-radius: var(--radius-md);
+  box-shadow: none;
+}
+
+.view-toggle {
+  border-radius: var(--radius-md);
+}
+
+.search-results {
+  top: 92px;
+  background: var(--surface-strong);
+  box-shadow: var(--shadow-lg);
+}
+
+@media (max-width: 1240px) {
+  .topbar {
+    position: static;
+  }
+
+  .hero-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .search-results {
+    top: 150px;
+  }
+}
+
+@media (max-width: 760px) {
+  .shell {
+    padding: 12px;
+  }
+
+  .hero-copy h3 {
+    max-width: none;
+    font-size: 1.38rem;
+  }
+
+  .topbar,
+  .hero-card,
+  .table-card,
+  .detail-card,
+  .list-card,
+  .chart-card,
+  .form-card {
+    padding: 14px;
+  }
+
+  .panel-header,
+  .job-card__header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .panel-header-actions,
+  .button-row,
+  .pagination-controls {
+    width: 100%;
+  }
+
+  .command-card {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .workflow-card {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .account-preset-strip {
+    grid-template-columns: 1fr;
+  }
+
+  .command-card > button {
+    grid-column: 1 / -1;
+    width: 100%;
+  }
+
+  .workflow-card > button,
+  .workflow-card > a {
+    grid-column: 1 / -1;
+    width: 100%;
+  }
+
+  .panel-header-actions > *,
+  .button-row > *,
+  .pagination-controls > * {
+    flex: 1 1 auto;
+  }
+
+  .table-scroll {
+    border-radius: var(--radius-sm);
+  }
+}
+
+/* ══════════════════════════════════════════════════
    DARK MODE
    ══════════════════════════════════════════════════ */
 [data-theme="dark"] {
@@ -2363,9 +3184,9 @@ a {
   --line: rgba(255, 255, 255, 0.08);
   --border: rgba(255, 255, 255, 0.08);
   --line-strong: rgba(255, 255, 255, 0.14);
-  --shadow-md: 0 16px 32px rgba(0, 0, 0, 0.3);
-  --shadow-lg: 0 22px 46px rgba(0, 0, 0, 0.35);
-  --shadow-sm: 0 10px 24px rgba(0, 0, 0, 0.2);
+  --shadow-md: 0 12px 28px rgba(0, 0, 0, 0.26);
+  --shadow-lg: 0 18px 40px rgba(0, 0, 0, 0.32);
+  --shadow-sm: 0 7px 18px rgba(0, 0, 0, 0.22);
   --accent: #4d8ef7;
   --accent-soft: rgba(77, 142, 247, 0.15);
   --success: #2ecc71;
@@ -2377,24 +3198,28 @@ a {
 }
 
 [data-theme="dark"] body {
-  background:
-    radial-gradient(circle at top left, rgba(77, 142, 247, 0.08), transparent 26%),
-    radial-gradient(circle at 85% 0%, rgba(46, 204, 113, 0.06), transparent 22%),
-    linear-gradient(180deg, #0f1728 0%, #0a1020 100%);
+  background: linear-gradient(180deg, #0f1728 0%, #0a1020 100%);
 }
 
 [data-theme="dark"] body::before {
-  opacity: 0.4;
+  content: none;
 }
 
 [data-theme="dark"] .brand-card {
-  background:
-    radial-gradient(circle at top right, rgba(77, 142, 247, 0.25), transparent 34%),
-    linear-gradient(180deg, #1a2744 0%, #0f1728 100%);
+  background: linear-gradient(180deg, #1a2744 0%, #0f1728 100%);
 }
 
 [data-theme="dark"] .topbar {
   background: rgba(22, 32, 51, 0.95);
+}
+
+[data-theme="dark"] .search-shell {
+  background: var(--surface-muted);
+}
+
+[data-theme="dark"] .preset-button:hover,
+[data-theme="dark"] .preset-button.active {
+  background: #1d2b49;
 }
 
 [data-theme="dark"] .brand-card,
@@ -3376,3 +4201,402 @@ body.print-mode .sidebar,
 body.print-mode .topbar { display: none !important; }
 body.print-mode .shell { display: block !important; }
 body.print-mode .main { margin: 0 !important; padding: 10px !important; max-width: 100% !important; }
+
+/* ══════════════════════════════════════════════════
+   v0 import: static-app frontend polish
+   ══════════════════════════════════════════════════ */
+:root {
+  --bg: #f8fafc;
+  --bg-soft: #eef2f6;
+  --surface: #ffffff;
+  --surface-strong: #ffffff;
+  --surface-muted: #f3f6fa;
+  --surface-ink: #111827;
+  --ink: #172033;
+  --muted: #66758b;
+  --text: #172033;
+  --text-muted: #66758b;
+  --line: rgba(23, 32, 51, 0.1);
+  --border: rgba(23, 32, 51, 0.1);
+  --line-strong: rgba(23, 32, 51, 0.16);
+  --accent: #2563eb;
+  --accent-soft: rgba(37, 99, 235, 0.1);
+  --success: #0f8a67;
+  --success-soft: rgba(15, 138, 103, 0.11);
+  --warning: #b7791f;
+  --warning-soft: rgba(183, 121, 31, 0.13);
+  --danger: #c2414b;
+  --danger-soft: rgba(194, 65, 75, 0.11);
+  --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.04), 0 1px 0 rgba(15, 23, 42, 0.03);
+  --shadow-md: 0 10px 24px rgba(15, 23, 42, 0.06);
+  --shadow-lg: 0 22px 48px rgba(15, 23, 42, 0.11);
+  --sidebar-bg: #101827;
+  --sidebar-panel: rgba(255, 255, 255, 0.055);
+  --sidebar-line: rgba(255, 255, 255, 0.1);
+  --sidebar-text: #eef2f7;
+  --sidebar-muted: #9aa6b6;
+}
+
+body {
+  background: var(--bg);
+}
+
+.page-noise {
+  opacity: 0.035;
+}
+
+.shell {
+  width: 100%;
+  max-width: none;
+  min-height: 100vh;
+  grid-template-columns: 264px minmax(0, 1fr);
+  gap: 0;
+  padding: 0;
+}
+
+.sidebar {
+  position: sticky;
+  top: 0;
+  max-height: 100vh;
+  min-height: 100vh;
+  gap: 14px;
+  padding: 16px 12px;
+  overflow-y: auto;
+  background: var(--sidebar-bg);
+  border-right: 1px solid var(--sidebar-line);
+}
+
+.main {
+  min-height: 100vh;
+  padding: 20px 24px 34px;
+}
+
+.brand-card {
+  padding: 10px 12px 16px;
+  border: 0;
+  border-bottom: 1px solid var(--sidebar-line);
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  color: var(--sidebar-text);
+}
+
+.brand-card .eyebrow {
+  color: var(--sidebar-muted);
+}
+
+.brand-card h1 {
+  margin-top: 6px;
+  font-size: 1.28rem;
+}
+
+.brand-copy {
+  margin-top: 8px;
+  color: var(--sidebar-muted);
+  font-size: 0.84rem;
+  line-height: 1.45;
+}
+
+.nav {
+  gap: 4px;
+}
+
+.nav a {
+  min-height: 42px;
+  padding: 9px 10px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--sidebar-muted);
+  box-shadow: none;
+}
+
+.nav a::before {
+  flex: 0 0 28px;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  background: var(--sidebar-panel);
+  color: var(--sidebar-muted);
+}
+
+.nav a:hover,
+.nav a.active {
+  background: rgba(255, 255, 255, 0.075);
+  border-color: var(--sidebar-line);
+  color: var(--sidebar-text);
+  box-shadow: none;
+}
+
+.nav a.active::before {
+  background: var(--accent);
+  color: #ffffff;
+}
+
+.nav-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.nav-shortcut {
+  padding: 3px 6px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.07);
+  color: var(--sidebar-muted);
+  font-size: 0.66rem;
+  font-weight: 700;
+}
+
+.sidebar-footnote {
+  padding: 12px;
+  border-color: var(--sidebar-line);
+  background: var(--sidebar-panel);
+  color: var(--sidebar-muted);
+  box-shadow: none;
+}
+
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  margin: -20px -24px 18px;
+  padding: 14px 24px;
+  border-width: 0 0 1px;
+  border-radius: 0;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: none;
+  backdrop-filter: blur(14px);
+}
+
+.topbar h2 {
+  margin-top: 4px;
+  font-size: 1.32rem;
+}
+
+.topbar-tools {
+  gap: 10px;
+}
+
+.search-shell {
+  min-width: min(36vw, 420px);
+  padding: 8px 10px;
+  border-color: var(--line);
+  background: var(--surface-muted);
+}
+
+.search-shell input::placeholder {
+  color: rgba(102, 117, 139, 0.74);
+}
+
+.view-root {
+  gap: 18px;
+}
+
+.hero-card,
+.table-card,
+.detail-card,
+.list-card,
+.chart-card,
+.form-card,
+.metric-card,
+.action-card,
+.trust-card,
+.story-card,
+.playbook-card,
+.status-item,
+.empty-state,
+.search-results {
+  border-color: var(--line);
+  background: var(--surface);
+  box-shadow: var(--shadow-sm);
+}
+
+.hero-card,
+.table-card,
+.detail-card,
+.list-card,
+.chart-card,
+.form-card {
+  padding: 20px;
+}
+
+.hero-card {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.07), rgba(15, 138, 103, 0.045) 42%, #ffffff 72%);
+}
+
+.metric-card,
+.action-card,
+.trust-card,
+.story-card {
+  transition: transform 140ms ease, box-shadow 140ms ease, border-color 140ms ease;
+}
+
+.metric-card:hover,
+.action-card:hover,
+.trust-card:hover,
+.story-card:hover,
+.table-card:hover,
+.detail-card:hover,
+.list-card:hover,
+.chart-card:hover,
+.form-card:hover {
+  border-color: rgba(37, 99, 235, 0.18);
+  box-shadow: var(--shadow-md);
+}
+
+.metric-value {
+  color: var(--surface-ink);
+  font-size: clamp(1.7rem, 3vw, 2.25rem);
+  letter-spacing: 0;
+}
+
+.metric-label,
+.table th,
+.eyebrow,
+.story-card__label,
+.signal-chip__label,
+.trust-card__eyebrow {
+  color: var(--muted);
+  letter-spacing: 0;
+}
+
+.table-scroll {
+  border: 1px solid var(--line);
+  background: var(--surface);
+}
+
+.table th {
+  background: #f8fafc;
+}
+
+.table td {
+  background: #ffffff;
+}
+
+.table tr:hover td {
+  background: rgba(37, 99, 235, 0.035);
+}
+
+.empty-state {
+  border-style: dashed;
+  background: linear-gradient(180deg, #ffffff, #f8fafc);
+  color: var(--muted);
+}
+
+.app-alert {
+  border-left: 4px solid var(--danger);
+}
+
+.skeleton,
+.skeleton-line,
+.skeleton-block {
+  position: relative;
+  overflow: hidden;
+  background: #e8edf4;
+}
+
+.skeleton::after,
+.skeleton-line::after,
+.skeleton-block::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.72), transparent);
+  animation: skeleton-sheen 1.4s infinite;
+}
+
+button:focus-visible,
+a:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 3px solid rgba(37, 99, 235, 0.24);
+  outline-offset: 2px;
+}
+
+@keyframes skeleton-sheen {
+  100% { transform: translateX(100%); }
+}
+
+[data-theme="dark"] {
+  --bg: #0d1320;
+  --bg-soft: #121a2a;
+  --surface: #151e2e;
+  --surface-strong: #172235;
+  --surface-muted: #101827;
+  --surface-ink: #f5f7fb;
+  --ink: #eef2f7;
+  --muted: #a8b3c4;
+  --text: #eef2f7;
+  --text-muted: #a8b3c4;
+  --line: rgba(255, 255, 255, 0.1);
+  --line-strong: rgba(255, 255, 255, 0.17);
+  --border: rgba(255, 255, 255, 0.1);
+}
+
+[data-theme="dark"] .topbar {
+  background: rgba(21, 30, 46, 0.9);
+}
+
+[data-theme="dark"] .hero-card {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.14), rgba(15, 138, 103, 0.1) 42%, var(--surface) 72%);
+}
+
+[data-theme="dark"] .table th,
+[data-theme="dark"] .table td,
+[data-theme="dark"] .table-scroll,
+[data-theme="dark"] .empty-state {
+  background: var(--surface);
+}
+
+[data-theme="dark"] .skeleton,
+[data-theme="dark"] .skeleton-line,
+[data-theme="dark"] .skeleton-block {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+@media (max-width: 1240px) {
+  .shell {
+    display: block;
+    padding: 0;
+  }
+
+  .main {
+    padding: 16px;
+  }
+
+  .topbar {
+    margin: -16px -16px 16px;
+    padding: 12px 16px;
+  }
+
+  .sidebar.mobile-open {
+    background: var(--sidebar-bg);
+    color: var(--sidebar-text);
+  }
+}
+
+@media (max-width: 760px) {
+  .topbar-tools {
+    gap: 8px;
+  }
+
+  .search-shell {
+    min-width: 0;
+  }
+
+  .hero-card,
+  .table-card,
+  .detail-card,
+  .list-card,
+  .chart-card,
+  .form-card {
+    padding: 16px;
+  }
+
+  .metric-card {
+    min-height: 112px;
+  }
+}

--- a/app/sw.js
+++ b/app/sw.js
@@ -1,4 +1,4 @@
-const ASSET_VERSION = '20260425-v0-polish-setup-bg-6';
+const ASSET_VERSION = '20260425-v0-polish-setup-bg-7';
 const CACHE_NAME = `bd-engine-${ASSET_VERSION}`;
 const SHELL_FILES = [
   '/',

--- a/app/sw.js
+++ b/app/sw.js
@@ -1,4 +1,4 @@
-const ASSET_VERSION = '20260425-v0-polish-setup-bg-3';
+const ASSET_VERSION = '20260425-v0-polish-setup-bg-4';
 const CACHE_NAME = `bd-engine-${ASSET_VERSION}`;
 const SHELL_FILES = [
   '/',

--- a/app/sw.js
+++ b/app/sw.js
@@ -1,4 +1,4 @@
-const ASSET_VERSION = '20260425-v0-polish-setup-bg-1';
+const ASSET_VERSION = '20260425-v0-polish-setup-bg-2';
 const CACHE_NAME = `bd-engine-${ASSET_VERSION}`;
 const SHELL_FILES = [
   '/',

--- a/app/sw.js
+++ b/app/sw.js
@@ -1,4 +1,4 @@
-const ASSET_VERSION = '20260425-v0-polish-setup-bg-2';
+const ASSET_VERSION = '20260425-v0-polish-setup-bg-3';
 const CACHE_NAME = `bd-engine-${ASSET_VERSION}`;
 const SHELL_FILES = [
   '/',

--- a/app/sw.js
+++ b/app/sw.js
@@ -1,4 +1,4 @@
-const ASSET_VERSION = '20260425-v0-polish-setup-bg-4';
+const ASSET_VERSION = '20260425-v0-polish-setup-bg-5';
 const CACHE_NAME = `bd-engine-${ASSET_VERSION}`;
 const SHELL_FILES = [
   '/',

--- a/app/sw.js
+++ b/app/sw.js
@@ -1,4 +1,4 @@
-const ASSET_VERSION = '20260425-v0-polish-setup-bg-5';
+const ASSET_VERSION = '20260425-v0-polish-setup-bg-6';
 const CACHE_NAME = `bd-engine-${ASSET_VERSION}`;
 const SHELL_FILES = [
   '/',

--- a/app/sw.js
+++ b/app/sw.js
@@ -1,10 +1,11 @@
-const CACHE_NAME = 'bd-engine-v1';
+const ASSET_VERSION = '20260425-v0-polish-setup-bg-1';
+const CACHE_NAME = `bd-engine-${ASSET_VERSION}`;
 const SHELL_FILES = [
   '/',
   '/index.html',
-  '/styles.css',
-  '/app.js',
-  '/local-api.js',
+  `/styles.css?v=${ASSET_VERSION}`,
+  `/app.js?v=${ASSET_VERSION}`,
+  `/local-api.js?v=${ASSET_VERSION}`,
   '/manifest.json',
 ];
 
@@ -26,7 +27,7 @@ self.addEventListener('activate', (event) => {
   self.clients.claim();
 });
 
-// Fetch: network-first for API, cache-first for shell
+// Fetch: network-first for API and shell, cache fallback for offline use
 self.addEventListener('fetch', (event) => {
   const url = new URL(event.request.url);
 
@@ -43,25 +44,22 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
-  // Static assets: cache-first, fallback to network
+  // Static assets: prefer fresh local files so UI/code changes are visible immediately.
   event.respondWith(
-    caches.match(event.request).then((cached) => {
-      if (cached) {
-        // Return cached, but also update cache in background
-        fetch(event.request).then((response) => {
-          if (response && response.ok) {
-            caches.open(CACHE_NAME).then((cache) => cache.put(event.request, response));
-          }
-        }).catch(() => {});
-        return cached;
+    fetch(event.request).then((response) => {
+      if (response && response.ok) {
+        const clone = response.clone();
+        caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
       }
-      return fetch(event.request).then((response) => {
-        if (response && response.ok) {
-          const clone = response.clone();
-          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
-        }
-        return response;
-      });
-    })
+      return response;
+    }).catch(() =>
+      caches.match(event.request).then((cached) => {
+        if (cached) return cached;
+        return caches.match(url.pathname).then((pathCached) => {
+          if (pathCached) return pathCached;
+          return new Response('Offline', { status: 503, headers: { 'Content-Type': 'text/plain' } });
+        });
+      })
+    )
   );
 });

--- a/packaging/empty-data/sample-linkedin-connections.csv
+++ b/packaging/empty-data/sample-linkedin-connections.csv
@@ -1,0 +1,1 @@
+First Name,Last Name,URL,Email Address,Company,Position,Connected On

--- a/packaging/windows/BD-Engine-Launcher.ps1
+++ b/packaging/windows/BD-Engine-Launcher.ps1
@@ -100,7 +100,7 @@ try {
     }
 
     $env:BD_ENGINE_DATA_ROOT = $DataRoot
-    $baseUrl = "http://localhost:$Port"
+    $baseUrl = "http://127.0.0.1:$Port"
     $appUrl = "$baseUrl/"
     Write-LauncherLog "Launch requested. installRoot=$installRoot dataRoot=$DataRoot port=$Port"
 

--- a/server/Modules/BdEngine.BackgroundJobs.psm1
+++ b/server/Modules/BdEngine.BackgroundJobs.psm1
@@ -935,7 +935,11 @@ function Invoke-BackgroundConnectionsCsvImportJob {
     $progressCallback = if ($JobId) { New-BackgroundJobProgressCallback -JobId $JobId } else { $null }
     $sourceLabel = [string](Get-ObjectValue -Object $Payload -Name 'sourceLabel' -Default 'linkedin-connections-csv')
     $mergeExisting = [bool](Test-Truthy (Get-ObjectValue -Object $Payload -Name 'mergeExisting' -Default $false))
+    $sourceFileName = [string](Get-ObjectValue -Object $Payload -Name 'sourceFileName' -Default '')
+    $sourceByteLength = [int64](Get-ObjectValue -Object $Payload -Name 'sourceByteLength' -Default 0)
     try {
+        $progressLabel = if ($sourceFileName) { "Importing LinkedIn connections CSV ($sourceFileName)" } else { 'Importing LinkedIn connections CSV' }
+        if ($JobId) { Update-AppBackgroundJobProgress -JobId $JobId -ProgressMessage $progressLabel | Out-Null }
         $result = Import-BdConnectionsCsv `
             -CsvPath ([string]$Payload.csvPath) `
             -SourceLabel $sourceLabel `
@@ -959,6 +963,10 @@ function Invoke-BackgroundConnectionsCsvImportJob {
     return [ordered]@{
         importRun = $result.importRun
         stats = $result.importRun.stats
+        source = [ordered]@{
+            fileName = $sourceFileName
+            byteLength = $sourceByteLength
+        }
         persistence = $persistence
     }
 }

--- a/server/Modules/BdEngine.BackgroundJobs.psm1
+++ b/server/Modules/BdEngine.BackgroundJobs.psm1
@@ -933,11 +933,20 @@ function Invoke-BackgroundConnectionsCsvImportJob {
     param($Payload, [string]$JobId)
 
     $progressCallback = if ($JobId) { New-BackgroundJobProgressCallback -JobId $JobId } else { $null }
-    $result = Import-BdConnectionsCsv -CsvPath ([string]$Payload.csvPath) -SourceLabel 'linkedin-connections-csv' -SkipPersistence -ProgressCallback $progressCallback
-
-    # Clean up temp file created from uploaded CSV content
-    if ($Payload.isTempFile -and (Test-Path -LiteralPath ([string]$Payload.csvPath))) {
-        Remove-Item -LiteralPath ([string]$Payload.csvPath) -Force -ErrorAction SilentlyContinue
+    $sourceLabel = [string](Get-ObjectValue -Object $Payload -Name 'sourceLabel' -Default 'linkedin-connections-csv')
+    $mergeExisting = [bool](Test-Truthy (Get-ObjectValue -Object $Payload -Name 'mergeExisting' -Default $false))
+    try {
+        $result = Import-BdConnectionsCsv `
+            -CsvPath ([string]$Payload.csvPath) `
+            -SourceLabel $sourceLabel `
+            -MergeExisting:$mergeExisting `
+            -SkipPersistence `
+            -ProgressCallback $progressCallback
+    } finally {
+        # Clean up temp file created from uploaded CSV content.
+        if ($Payload.isTempFile -and (Test-Path -LiteralPath ([string]$Payload.csvPath))) {
+            Remove-Item -LiteralPath ([string]$Payload.csvPath) -Force -ErrorAction SilentlyContinue
+        }
     }
 
     $persistence = Save-BackgroundJobState -State $result.state -Segments @('Contacts', 'Companies', 'BoardConfigs', 'ImportRuns') -JobId $JobId -OperationName 'connections-csv-import'
@@ -1994,12 +2003,13 @@ function Invoke-BackgroundJobHandler {
         if ($result -isnot [System.Collections.IDictionary]) {
             $result = [ordered]@{ value = $result }
         }
-        $result.durationMs = $durationMs
+        [void](Set-ObjectValue -Object $result -Name 'durationMs' -Value $durationMs)
 
-        if ($result.timings) {
+        $timings = Get-ObjectValue -Object $result -Name 'timings' -Default $null
+        if ($timings) {
             $phaseParts = New-Object System.Collections.ArrayList
-            foreach ($name in @($result.timings.Keys)) {
-                [void]$phaseParts.Add(('{0}={1}ms' -f $name, [int]$result.timings[$name]))
+            foreach ($name in @($timings.Keys)) {
+                [void]$phaseParts.Add(('{0}={1}ms' -f $name, [int]$timings[$name]))
             }
             if ($phaseParts.Count -gt 0) {
                 Write-BackgroundJobLog ("JOB timings id={0} type={1} {2}" -f $Job.id, $Job.type, ([string]::Join(' ', @($phaseParts))))

--- a/server/Modules/BdEngine.BackgroundJobs.psm1
+++ b/server/Modules/BdEngine.BackgroundJobs.psm1
@@ -245,7 +245,7 @@ function Ensure-BackgroundWorkerRunning {
         '-ExecutionPolicy',
         'Bypass',
         '-File',
-        $workerScript
+        ('"{0}"' -f $workerScript)
     ) -WindowStyle Hidden -WorkingDirectory (Get-AppProjectRootPath) -PassThru
 
     Set-Content -LiteralPath (Get-BackgroundWorkerPidPath) -Value ([string]$process.Id)

--- a/server/Modules/BdEngine.BackgroundJobs.psm1
+++ b/server/Modules/BdEngine.BackgroundJobs.psm1
@@ -949,6 +949,12 @@ function Invoke-BackgroundConnectionsCsvImportJob {
         }
     }
 
+    $stats = $result.importRun.stats
+    $actionableRows = [int](Get-ObjectValue -Object $stats -Name 'imported' -Default 0) + [int](Get-ObjectValue -Object $stats -Name 'updated' -Default 0)
+    if ($actionableRows -le 0) {
+        throw 'No LinkedIn connection rows were found. Choose the unzipped Connections.csv export from LinkedIn with headers like First Name, Last Name, URL, Email Address, Company, Position, and Connected On.'
+    }
+
     $persistence = Save-BackgroundJobState -State $result.state -Segments @('Contacts', 'Companies', 'BoardConfigs', 'ImportRuns') -JobId $JobId -OperationName 'connections-csv-import'
     return [ordered]@{
         importRun = $result.importRun

--- a/server/Modules/BdEngine.Domain.psm1
+++ b/server/Modules/BdEngine.Domain.psm1
@@ -516,7 +516,14 @@ function Test-ObjectHasKey {
     }
 
     if ($Object -is [System.Collections.IDictionary]) {
-        return $Object.Contains($Name)
+        if ($Object.PSObject.Methods.Name -contains 'ContainsKey') {
+            return $Object.ContainsKey($Name)
+        }
+        try {
+            return $Object.Contains($Name)
+        } catch {
+            return $false
+        }
     }
 
     return [bool]$Object.PSObject.Properties[$Name]
@@ -5549,7 +5556,7 @@ function Set-AccountFields {
         }
 
         foreach ($key in @('canonicalDomain', 'careersUrl', 'domain', 'enrichmentStatus', 'enrichmentSource', 'enrichmentConfidence', 'enrichmentConfidenceScore', 'linkedinCompanySlug', 'aliases', 'tags')) {
-            if ($account -is [System.Collections.IDictionary] -and -not $account.Contains($key)) {
+            if ($account -is [System.Collections.IDictionary] -and -not (Test-ObjectHasKey -Object $account -Name $key)) {
                 $account[$key] = $null
             }
         }
@@ -5687,14 +5694,14 @@ function Add-Activity {
 
     # Ensure optional keys exist before access (strict-mode safe)
     foreach ($optKey in 'contactId', 'type', 'summary', 'notes', 'pipelineStage', 'metadata') {
-        if ($Payload -is [System.Collections.IDictionary] -and -not $Payload.Contains($optKey)) {
+        if ($Payload -is [System.Collections.IDictionary] -and -not (Test-ObjectHasKey -Object $Payload -Name $optKey)) {
             $Payload[$optKey] = $null
         }
     }
 
     $activity = [ordered]@{
         id = New-RandomId -Prefix 'act'
-        workspaceId = $State.workspace.id
+        workspaceId = [string](Get-ObjectValue -Object (Get-ObjectValue -Object $State -Name 'workspace' -Default $null) -Name 'id' -Default 'workspace-default')
         accountId = [string]$Payload.accountId
         contactId = if ($Payload.contactId) { [string]$Payload.contactId } else { '' }
         normalizedCompanyName = $normalizedCompanyName
@@ -5722,7 +5729,7 @@ function Add-Activity {
     if ($relatedAccount) {
         # Ensure keys exist before writing (strict-mode safe)
         foreach ($k in 'lastContactedAt', 'outreachStatus') {
-            if ($relatedAccount -is [System.Collections.IDictionary] -and -not $relatedAccount.Contains($k)) {
+            if ($relatedAccount -is [System.Collections.IDictionary] -and -not (Test-ObjectHasKey -Object $relatedAccount -Name $k)) {
                 $relatedAccount[$k] = $null
             }
         }
@@ -5731,7 +5738,7 @@ function Add-Activity {
             $relatedAccount['outreachStatus'] = $activity.pipelineStage
         }
         $relatedActivities = @($State.activities | Where-Object {
-                ([string](Get-ObjectValue -Object $_ -Name 'accountId' -Default '')) -eq [string]$relatedAccount.id -or
+                ([string](Get-ObjectValue -Object $_ -Name 'accountId' -Default '')) -eq [string](Get-ObjectValue -Object $relatedAccount -Name 'id' -Default '') -or
                 ([string](Get-ObjectValue -Object $_ -Name 'normalizedCompanyName' -Default '')) -eq [string]$normalizedCompanyName
             })
         $relatedAccount = Update-CompanyProjection -Company $relatedAccount -Activities $relatedActivities

--- a/server/Modules/BdEngine.Domain.psm1
+++ b/server/Modules/BdEngine.Domain.psm1
@@ -8,21 +8,52 @@ $script:FilterOptionsCacheSignature = ''
 $script:RoleSeniorityScoreCache = @{}
 $script:DecisionMakerFitScoreCache = @{}
 
-# ─── Fixed owner roster ───
+# Legacy fallback owner roster for existing development workspaces.
 $script:OwnerRoster = @(
     [ordered]@{ ownerId = 'derek-grant';  displayName = 'Derek Grant' }
     [ordered]@{ ownerId = 'alex-chong';   displayName = 'Alex Chong' }
     [ordered]@{ ownerId = 'danny-chung';  displayName = 'Danny Chung' }
 )
 
+function Get-ConfiguredOwnerRoster {
+    try {
+        $settings = Get-AppSegment -Segment 'Settings'
+        $configured = @(Get-ObjectValue -Object $settings -Name 'ownerRoster' -Default @())
+        $owners = New-Object System.Collections.ArrayList
+        foreach ($owner in @($configured)) {
+            $displayName = [string](Get-ObjectValue -Object $owner -Name 'displayName' -Default '')
+            $ownerId = [string](Get-ObjectValue -Object $owner -Name 'ownerId' -Default '')
+            if (-not [string]::IsNullOrWhiteSpace($displayName) -and -not [string]::IsNullOrWhiteSpace($ownerId)) {
+                [void]$owners.Add([ordered]@{
+                    ownerId = $ownerId
+                    displayName = $displayName
+                    email = [string](Get-ObjectValue -Object $owner -Name 'email' -Default '')
+                })
+            }
+        }
+        if ($owners.Count -gt 0) {
+            return @($owners)
+        }
+    } catch {
+        return @()
+    }
+
+    return @()
+}
+
 function Get-OwnerRoster {
+    $configured = @(Get-ConfiguredOwnerRoster)
+    if ($configured.Count -gt 0) {
+        return @($configured)
+    }
+
     return @($script:OwnerRoster)
 }
 
 function Resolve-OwnerDisplayName {
     param([string]$OwnerIdOrName)
     if (-not $OwnerIdOrName) { return '' }
-    $match = $script:OwnerRoster | Where-Object {
+    $match = Get-OwnerRoster | Where-Object {
         $_.ownerId -eq $OwnerIdOrName -or $_.displayName -eq $OwnerIdOrName
     } | Select-Object -First 1
     if ($match) { return [string]$match.displayName }
@@ -32,7 +63,7 @@ function Resolve-OwnerDisplayName {
 function Resolve-OwnerId {
     param([string]$OwnerIdOrName)
     if (-not $OwnerIdOrName) { return '' }
-    $match = $script:OwnerRoster | Where-Object {
+    $match = Get-OwnerRoster | Where-Object {
         $_.ownerId -eq $OwnerIdOrName -or $_.displayName -eq $OwnerIdOrName
     } | Select-Object -First 1
     if ($match) { return [string]$match.ownerId }
@@ -4629,14 +4660,15 @@ function Update-DerivedData {
             continue
         }
 
+        $workspaceId = [string](Get-ObjectValue -Object $State.workspace -Name 'id' -Default 'workspace-default')
         $company = if ($existing) {
             $existing
         } else {
-            New-CompanyProjection -WorkspaceId $State.workspace.id -NormalizedName $companyKey -DisplayName $displayName
+            New-CompanyProjection -WorkspaceId $workspaceId -NormalizedName $companyKey -DisplayName $displayName
         }
-        $company.workspaceId = $State.workspace.id
-        $company.normalizedName = $companyKey
-        $company.displayName = $displayName
+        [void](Set-ObjectValue -Object $company -Name 'workspaceId' -Value $workspaceId)
+        [void](Set-ObjectValue -Object $company -Name 'normalizedName' -Value $companyKey)
+        [void](Set-ObjectValue -Object $company -Name 'displayName' -Value $displayName)
         $company = Update-CompanyProjection `
             -Company $company `
             -Contacts $contacts `
@@ -4675,7 +4707,8 @@ function Update-DerivedData {
     $projectionStopwatch.Stop()
 
     $sortStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
-    $State.companies = Sort-Companies -Companies @($derivedCompanies) -ChangedKeys $touchedKeySet
+    $sortedCompanies = @(Sort-Companies -Companies @($derivedCompanies.ToArray()) -ChangedKeys $touchedKeySet)
+    [void](Set-ObjectValue -Object $State -Name 'companies' -Value $sortedCompanies)
     $sortStopwatch.Stop()
     if ($TimingBag) {
         $TimingBag['groupingMs'] = [int]$groupingStopwatch.Elapsed.TotalMilliseconds

--- a/server/Modules/BdEngine.Domain.psm1
+++ b/server/Modules/BdEngine.Domain.psm1
@@ -4506,7 +4506,7 @@ function Sort-Companies {
             $lo = 0
             $hi = $unchanged.Count
             while ($lo -lt $hi) {
-                $mid = [int](($lo + $hi) / 2)
+                $mid = [int][Math]::Floor(($lo + $hi) / 2)
                 $midKey = Get-CompanySortKey -Company $unchanged[$mid]
                 if ((Compare-CompanySortKeys -KeyA $companyKey -KeyB $midKey) -le 0) {
                     $hi = $mid

--- a/server/Modules/BdEngine.Import.psm1
+++ b/server/Modules/BdEngine.Import.psm1
@@ -591,6 +591,50 @@ function Add-LinkedInIncomingKeys {
     }
 }
 
+function Test-LinkedInCsvHeaderLine {
+    param([string]$Line)
+
+    if ([string]::IsNullOrWhiteSpace($Line)) {
+        return $false
+    }
+
+    $columns = @($Line -split ',' | ForEach-Object {
+        Normalize-TextKey (($_ -replace '^\s*"', '') -replace '"\s*$', '')
+    })
+    $hasName = ($columns -contains 'first name') -or ($columns -contains 'last name') -or ($columns -contains 'full name') -or ($columns -contains 'name')
+    $hasContactSignal = ($columns -contains 'url') -or ($columns -contains 'profile url') -or ($columns -contains 'linkedin url') -or ($columns -contains 'email address') -or ($columns -contains 'email')
+    $hasCompanySignal = ($columns -contains 'company') -or ($columns -contains 'company name') -or ($columns -contains 'organization') -or ($columns -contains 'position') -or ($columns -contains 'title') -or ($columns -contains 'job title')
+
+    return ($hasName -and ($hasContactSignal -or $hasCompanySignal))
+}
+
+function Get-LinkedInCsvDataContent {
+    param([string]$CsvContent)
+
+    $cleanContent = if ($null -eq $CsvContent) { '' } else { [string]$CsvContent }
+    $cleanContent = $cleanContent -replace '^\uFEFF', ''
+    $cleanContent = $cleanContent -replace '^(?:[ \t]*\r?\n)+', ''
+    $lines = @($cleanContent -split '\r?\n')
+    $headerIndex = 0
+    $headerDetected = $false
+
+    for ($index = 0; $index -lt $lines.Count; $index++) {
+        if (Test-LinkedInCsvHeaderLine -Line $lines[$index]) {
+            $headerIndex = $index
+            $headerDetected = $true
+            break
+        }
+    }
+
+    $dataLines = if ($lines.Count -gt 0) { @($lines[$headerIndex..($lines.Count - 1)]) } else { @() }
+    return [ordered]@{
+        content = [string]::Join([Environment]::NewLine, $dataLines)
+        headerDetected = $headerDetected
+        skippedLeadingLines = $headerIndex
+        headerLine = if ($lines.Count -gt 0) { [string]$lines[$headerIndex] } else { '' }
+    }
+}
+
 function New-BdConnectionsCsvImportPlan {
     param(
         [Parameter(Mandatory = $true)]
@@ -600,14 +644,14 @@ function New-BdConnectionsCsvImportPlan {
         [int]$PreviewLimit = 25
     )
 
-    $csvContent = [System.IO.File]::ReadAllText($CsvPath)
-    $csvContent = $csvContent -replace '^\uFEFF', ''
-    $csvContent = $csvContent -replace '^(?:[ \t]*\r?\n)+', ''
+    $csvInfo = Get-LinkedInCsvDataContent -CsvContent ([System.IO.File]::ReadAllText($CsvPath))
+    $csvContent = [string]$csvInfo.content
     $rows = if ([string]::IsNullOrWhiteSpace($csvContent)) {
         @()
     } else {
         @(($csvContent -split '\r?\n') | ConvertFrom-Csv)
     }
+    $rows = @($rows)
     $contacts = New-Object System.Collections.ArrayList
     $preview = New-Object System.Collections.ArrayList
     $existingIndex = @{
@@ -802,6 +846,11 @@ function New-BdConnectionsCsvImportPlan {
         preview = @($preview)
         stats = $stats
         totalRows = @($rows).Count
+        metadata = [ordered]@{
+            headerDetected = [bool]$csvInfo.headerDetected
+            skippedLeadingLines = [int]$csvInfo.skippedLeadingLines
+            headerLine = [string]$csvInfo.headerLine
+        }
     }
 }
 
@@ -875,6 +924,7 @@ function Import-BdConnectionsCsv {
     foreach ($cfg in @($state.boardConfigs)) { $k = Get-CanonicalCompanyKey ([string]$cfg.companyName); if ($k) { [void]$preConfigKeys.Add($k) } }
     $state = Sync-BoardConfigsFromCompanies -State $state -ProgressCallback $ProgressCallback
     $postConfigTouched = @($state.boardConfigs | ForEach-Object { Get-CanonicalCompanyKey ([string]$_.companyName) } | Where-Object { $_ -and -not $preConfigKeys.Contains($_) } | Select-Object -Unique)
+    $postConfigTouched = @($postConfigTouched)
     $configTouchedKeys = if ($postConfigTouched.Count -gt 0) { $postConfigTouched } else { $null }
     $state = Update-DerivedData -State $state -ProgressCallback $ProgressCallback -TouchedCompanyKeys $configTouchedKeys
 
@@ -900,6 +950,9 @@ function Import-BdConnectionsCsv {
             dedupeKeys = @('linkedinUrl', 'email', 'name+company')
             mergeExisting = [bool]$MergeExisting
             previewCount = @($plan.preview).Count
+            headerDetected = [bool]$plan.metadata.headerDetected
+            skippedLeadingLines = [int]$plan.metadata.skippedLeadingLines
+            headerLine = [string]$plan.metadata.headerLine
         }
         errors = @()
     }

--- a/server/Modules/BdEngine.Import.psm1
+++ b/server/Modules/BdEngine.Import.psm1
@@ -854,6 +854,104 @@ function New-BdConnectionsCsvImportPlan {
     }
 }
 
+function Get-BdConnectionsCsvPreview {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$CsvPath,
+        [string]$SourceLabel = 'linkedin-connections-csv',
+        [switch]$UseEmptyState,
+        [switch]$MergeExisting
+    )
+
+    if (-not (Test-Path -LiteralPath $CsvPath)) {
+        throw "CSV file not found: $CsvPath"
+    }
+
+    $state = if ($UseEmptyState) {
+        [ordered]@{
+            workspace = [ordered]@{ id = 'workspace-default'; name = 'Dry Run Workspace' }
+            companies = @()
+            contacts = @()
+        }
+    } else {
+        Get-AppStateView -Segments @('Workspace', 'Companies', 'Contacts')
+    }
+
+    if ($null -eq $state.contacts) { $state.contacts = @() }
+    if ($null -eq $state.companies) { $state.companies = @() }
+
+    $plan = New-BdConnectionsCsvImportPlan -CsvPath $CsvPath -State $state
+    $incomingContacts = @($plan.contacts)
+    $mergedContacts = New-Object System.Collections.ArrayList
+    if ($MergeExisting) {
+        foreach ($contact in @($state.contacts)) {
+            $contactId = [string](Get-ObjectValue -Object $contact -Name 'id' -Default '')
+            if (-not $contactId -or -not $plan.touchedIds.Contains($contactId)) {
+                [void]$mergedContacts.Add($contact)
+            }
+        }
+    }
+    foreach ($contact in $incomingContacts) {
+        [void]$mergedContacts.Add($contact)
+    }
+
+    $companyKeys = New-Object 'System.Collections.Generic.HashSet[string]'
+    if ($MergeExisting) {
+        foreach ($company in @($state.companies)) {
+            $companyKey = Get-CanonicalCompanyKey ([string](Get-FirstResolvedText -Candidates @(
+                (Get-ObjectValue -Object $company -Name 'normalizedName' -Default ''),
+                (Get-ObjectValue -Object $company -Name 'normalizedCompanyName' -Default ''),
+                (Get-ObjectValue -Object $company -Name 'displayName' -Default ''),
+                (Get-ObjectValue -Object $company -Name 'companyName' -Default ''),
+                (Get-ObjectValue -Object $company -Name 'name' -Default '')
+            )))
+            if ($companyKey) { [void]$companyKeys.Add($companyKey) }
+        }
+    }
+    foreach ($contact in @($mergedContacts)) {
+        $companyKey = Get-CanonicalCompanyKey ([string](Get-FirstResolvedText -Candidates @(
+            (Get-ObjectValue -Object $contact -Name 'normalizedCompanyName' -Default ''),
+            (Get-ObjectValue -Object $contact -Name 'companyName' -Default '')
+        )))
+        if ($companyKey) { [void]$companyKeys.Add($companyKey) }
+    }
+
+    $startedAt = (Get-Date).ToString('o')
+    $importRun = [ordered]@{
+        id = New-RandomId -Prefix 'run'
+        workspaceId = [string](Get-ObjectValue -Object $state.workspace -Name 'id' -Default 'workspace-default')
+        type = 'connections-csv-import'
+        status = 'dry_run'
+        startedAt = $startedAt
+        finishedAt = (Get-Date).ToString('o')
+        summary = "Dry-run parsed LinkedIn connections CSV from $CsvPath"
+        stats = [ordered]@{
+            contacts = @($mergedContacts).Count
+            companies = $companyKeys.Count
+            rows = [int]$plan.stats.rows
+            imported = [int]$plan.stats.imported
+            updated = [int]$plan.stats.updated
+            skipped = [int]$plan.stats.skipped
+            failed = [int]$plan.stats.failed
+            source = $SourceLabel
+        }
+        metadata = [ordered]@{
+            dedupeKeys = @('linkedinUrl', 'email', 'name+company')
+            mergeExisting = [bool]$MergeExisting
+            previewCount = @($plan.preview).Count
+            headerDetected = [bool]$plan.metadata.headerDetected
+            skippedLeadingLines = [int]$plan.metadata.skippedLeadingLines
+            headerLine = [string]$plan.metadata.headerLine
+        }
+        errors = @()
+    }
+
+    return [ordered]@{
+        importRun = $importRun
+        preview = @($plan.preview)
+    }
+}
+
 function Import-BdConnectionsCsv {
     param(
         [Parameter(Mandatory = $true)]

--- a/server/Modules/BdEngine.Import.psm1
+++ b/server/Modules/BdEngine.Import.psm1
@@ -433,6 +433,378 @@ function Test-PlaceholderJobRow {
     return $false
 }
 
+function Get-LinkedInCsvValue {
+    param(
+        [Parameter(Mandatory = $true)]
+        $Row,
+        [Parameter(Mandatory = $true)]
+        [string[]]$Names
+    )
+
+    foreach ($property in @($Row.PSObject.Properties)) {
+        $propertyKey = Normalize-TextKey $property.Name
+        foreach ($name in $Names) {
+            if ($propertyKey -eq (Normalize-TextKey $name)) {
+                return [string]$property.Value
+            }
+        }
+    }
+
+    return ''
+}
+
+function Normalize-LinkedInImportText {
+    param([string]$Value)
+
+    if ([string]::IsNullOrWhiteSpace($Value)) {
+        return ''
+    }
+
+    return (($Value -replace '\s+', ' ').Trim())
+}
+
+function Normalize-LinkedInEmail {
+    param([string]$Value)
+
+    $email = (Normalize-LinkedInImportText $Value).ToLowerInvariant()
+    if ($email -and $email -match '^[^@\s]+@[^@\s]+\.[^@\s]+$') {
+        return $email
+    }
+
+    return ''
+}
+
+function Normalize-LinkedInUrlKey {
+    param([string]$Value)
+
+    $url = (Normalize-LinkedInImportText $Value)
+    if (-not $url) {
+        return ''
+    }
+
+    if ($url -match '^linkedin\.com/') {
+        $url = 'https://www.' + $url
+    } elseif ($url -match '^www\.linkedin\.com/') {
+        $url = 'https://' + $url
+    }
+
+    return ($url.TrimEnd('/') -replace '^http://', 'https://').ToLowerInvariant()
+}
+
+function Get-LinkedInContactDedupeKeys {
+    param($Contact)
+
+    $linkedinUrl = [string](Get-ObjectValue -Object $Contact -Name 'linkedinUrl' -Default '')
+    $email = [string](Get-ObjectValue -Object $Contact -Name 'email' -Default '')
+    $fullName = [string](Get-ObjectValue -Object $Contact -Name 'fullName' -Default '')
+    $companyName = [string](Get-ObjectValue -Object $Contact -Name 'companyName' -Default '')
+    if (-not $companyName) {
+        $companyName = [string](Get-ObjectValue -Object $Contact -Name 'normalizedCompanyName' -Default '')
+    }
+
+    $nameCompany = ''
+    $nameKey = Normalize-TextKey $fullName
+    $companyKey = Get-CanonicalCompanyKey $companyName
+    if ($nameKey -and $companyKey) {
+        $nameCompany = '{0}|{1}' -f $nameKey, $companyKey
+    }
+
+    return [ordered]@{
+        linkedinUrl = Normalize-LinkedInUrlKey $linkedinUrl
+        email = Normalize-LinkedInEmail $email
+        nameCompany = $nameCompany
+    }
+}
+
+function Add-LinkedInContactToIndex {
+    param(
+        [Parameter(Mandatory = $true)]
+        [hashtable]$Index,
+        [Parameter(Mandatory = $true)]
+        $Contact
+    )
+
+    $keys = Get-LinkedInContactDedupeKeys -Contact $Contact
+    if ($keys.linkedinUrl -and -not $Index.linkedinUrl.ContainsKey($keys.linkedinUrl)) {
+        $Index.linkedinUrl[$keys.linkedinUrl] = $Contact
+    }
+    if ($keys.email -and -not $Index.email.ContainsKey($keys.email)) {
+        $Index.email[$keys.email] = $Contact
+    }
+    if ($keys.nameCompany -and -not $Index.nameCompany.ContainsKey($keys.nameCompany)) {
+        $Index.nameCompany[$keys.nameCompany] = $Contact
+    }
+}
+
+function Find-LinkedInExistingContact {
+    param(
+        [Parameter(Mandatory = $true)]
+        [hashtable]$Index,
+        [Parameter(Mandatory = $true)]
+        $Keys
+    )
+
+    if ($Keys.linkedinUrl -and $Index.linkedinUrl.ContainsKey($Keys.linkedinUrl)) {
+        return $Index.linkedinUrl[$Keys.linkedinUrl]
+    }
+    if ($Keys.email -and $Index.email.ContainsKey($Keys.email)) {
+        return $Index.email[$Keys.email]
+    }
+    if ($Keys.nameCompany -and $Index.nameCompany.ContainsKey($Keys.nameCompany)) {
+        return $Index.nameCompany[$Keys.nameCompany]
+    }
+
+    return $null
+}
+
+function Test-LinkedInIncomingDuplicate {
+    param(
+        [Parameter(Mandatory = $true)]
+        [hashtable]$Seen,
+        [Parameter(Mandatory = $true)]
+        $Keys
+    )
+
+    foreach ($keyName in 'linkedinUrl', 'email', 'nameCompany') {
+        $key = [string]$Keys[$keyName]
+        if ($key -and $Seen[$keyName].Contains($key)) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+function Add-LinkedInIncomingKeys {
+    param(
+        [Parameter(Mandatory = $true)]
+        [hashtable]$Seen,
+        [Parameter(Mandatory = $true)]
+        $Keys
+    )
+
+    foreach ($keyName in 'linkedinUrl', 'email', 'nameCompany') {
+        $key = [string]$Keys[$keyName]
+        if ($key) {
+            [void]$Seen[$keyName].Add($key)
+        }
+    }
+}
+
+function New-BdConnectionsCsvImportPlan {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$CsvPath,
+        [Parameter(Mandatory = $true)]
+        $State,
+        [int]$PreviewLimit = 25
+    )
+
+    $csvContent = [System.IO.File]::ReadAllText($CsvPath)
+    $csvContent = $csvContent -replace '^\uFEFF', ''
+    $csvContent = $csvContent -replace '^(?:[ \t]*\r?\n)+', ''
+    $rows = if ([string]::IsNullOrWhiteSpace($csvContent)) {
+        @()
+    } else {
+        @(($csvContent -split '\r?\n') | ConvertFrom-Csv)
+    }
+    $contacts = New-Object System.Collections.ArrayList
+    $preview = New-Object System.Collections.ArrayList
+    $existingIndex = @{
+        linkedinUrl = @{}
+        email = @{}
+        nameCompany = @{}
+    }
+    $seen = @{
+        linkedinUrl = New-Object 'System.Collections.Generic.HashSet[string]'
+        email = New-Object 'System.Collections.Generic.HashSet[string]'
+        nameCompany = New-Object 'System.Collections.Generic.HashSet[string]'
+    }
+    $touchedIds = New-Object 'System.Collections.Generic.HashSet[string]'
+    $stats = [ordered]@{
+        rows = @($rows).Count
+        imported = 0
+        updated = 0
+        skipped = 0
+        failed = 0
+    }
+
+    foreach ($existingContact in @($State.contacts)) {
+        Add-LinkedInContactToIndex -Index $existingIndex -Contact $existingContact
+    }
+
+    for ($index = 0; $index -lt $rows.Count; $index++) {
+        $row = $rows[$index]
+        $rowNumber = $index + 2
+
+        try {
+            $firstName = Normalize-LinkedInImportText (Get-LinkedInCsvValue -Row $row -Names @('First Name', 'FirstName', 'First'))
+            $lastName = Normalize-LinkedInImportText (Get-LinkedInCsvValue -Row $row -Names @('Last Name', 'LastName', 'Last'))
+            $fullName = Normalize-LinkedInImportText (Get-LinkedInCsvValue -Row $row -Names @('Full Name', 'Name'))
+            if (-not $fullName) {
+                $fullName = (('{0} {1}' -f $firstName, $lastName) -replace '\s+', ' ').Trim()
+            }
+
+            $companyName = Get-CanonicalCompanyDisplayName (Get-FirstResolvedText -Candidates @(
+                (Get-LinkedInCsvValue -Row $row -Names @('Clean Company')),
+                (Get-LinkedInCsvValue -Row $row -Names @('Company', 'Company Name', 'Organization'))
+            ))
+            $normalizedCompanyName = Get-CanonicalCompanyKey $companyName
+            $title = Normalize-LinkedInImportText (Get-FirstResolvedText -Candidates @(
+                (Get-LinkedInCsvValue -Row $row -Names @('Position')),
+                (Get-LinkedInCsvValue -Row $row -Names @('Title', 'Job Title'))
+            ))
+            $email = Normalize-LinkedInEmail (Get-LinkedInCsvValue -Row $row -Names @('Email Address', 'Email', 'EmailAddress'))
+            $linkedinUrl = Normalize-LinkedInImportText (Get-FirstResolvedText -Candidates @(
+                (Get-LinkedInCsvValue -Row $row -Names @('URL', 'Profile URL', 'LinkedIn URL', 'LinkedIn'))
+            ))
+            $connectedOnRaw = Normalize-LinkedInImportText (Get-LinkedInCsvValue -Row $row -Names @('Connected On', 'ConnectedOn', 'Connected Date'))
+            $connectedOn = Get-FirstResolvedDateString -Candidates @($connectedOnRaw)
+
+            $keys = [ordered]@{
+                linkedinUrl = Normalize-LinkedInUrlKey $linkedinUrl
+                email = $email
+                nameCompany = if ((Normalize-TextKey $fullName) -and $normalizedCompanyName) { '{0}|{1}' -f (Normalize-TextKey $fullName), $normalizedCompanyName } else { '' }
+            }
+
+            if (-not $fullName -and -not $companyName -and -not $email -and -not $linkedinUrl) {
+                $stats.skipped++
+                if ($preview.Count -lt $PreviewLimit) {
+                    [void]$preview.Add([ordered]@{
+                        rowNumber = $rowNumber
+                        action = 'skipped'
+                        fullName = ''
+                        companyName = ''
+                        title = ''
+                        email = ''
+                        linkedinUrl = ''
+                        connectedOn = ''
+                        message = 'Row did not include a name, company, email, or LinkedIn URL.'
+                    })
+                }
+                continue
+            }
+
+            if (Test-LinkedInIncomingDuplicate -Seen $seen -Keys $keys) {
+                $stats.skipped++
+                if ($preview.Count -lt $PreviewLimit) {
+                    [void]$preview.Add([ordered]@{
+                        rowNumber = $rowNumber
+                        action = 'skipped'
+                        fullName = $fullName
+                        companyName = $companyName
+                        title = $title
+                        email = $email
+                        linkedinUrl = $linkedinUrl
+                        connectedOn = $connectedOn
+                        message = 'Duplicate row in this CSV.'
+                    })
+                }
+                continue
+            }
+
+            Add-LinkedInIncomingKeys -Seen $seen -Keys $keys
+            $existing = Find-LinkedInExistingContact -Index $existingIndex -Keys $keys
+            $action = if ($existing) { 'updated' } else { 'imported' }
+            $contactId = if ($existing) { [string](Get-ObjectValue -Object $existing -Name 'id' -Default '') } else { '' }
+            if (-not $contactId) {
+                $seed = '{0}|{1}|{2}|{3}|{4}' -f $normalizedCompanyName, $fullName, $title, $keys.linkedinUrl, $email
+                $contactId = New-DeterministicId -Prefix 'con' -Seed $seed
+            }
+
+            if ($existing) {
+                if (-not $firstName) { $firstName = [string](Get-ObjectValue -Object $existing -Name 'firstName' -Default '') }
+                if (-not $lastName) { $lastName = [string](Get-ObjectValue -Object $existing -Name 'lastName' -Default '') }
+                if (-not $fullName) { $fullName = [string](Get-ObjectValue -Object $existing -Name 'fullName' -Default '') }
+                if (-not $companyName) { $companyName = [string](Get-ObjectValue -Object $existing -Name 'companyName' -Default '') }
+                if (-not $normalizedCompanyName) { $normalizedCompanyName = [string](Get-ObjectValue -Object $existing -Name 'normalizedCompanyName' -Default '') }
+                if (-not $title) { $title = [string](Get-ObjectValue -Object $existing -Name 'title' -Default '') }
+                if (-not $linkedinUrl) { $linkedinUrl = [string](Get-ObjectValue -Object $existing -Name 'linkedinUrl' -Default '') }
+                if (-not $email) { $email = [string](Get-ObjectValue -Object $existing -Name 'email' -Default '') }
+                if (-not $connectedOn) { $connectedOn = [string](Get-ObjectValue -Object $existing -Name 'connectedOn' -Default '') }
+            }
+
+            $yearsConnectedRaw = Get-LinkedInCsvValue -Row $row -Names @('Years Connected')
+            $companyContacts = Get-LinkedInCsvValue -Row $row -Names @('Company Contacts')
+            $priorityScore = Get-LinkedInCsvValue -Row $row -Names @('Priority Score')
+            $yearsConnected = Get-FirstResolvedNumber -Candidates @($yearsConnectedRaw)
+            if ($yearsConnected -le 0 -and $connectedOn) {
+                $yearsConnected = Get-YearsConnectedFromDate -ConnectedOn $connectedOn
+            }
+            $titleFlags = Get-TitleFlags -Title $title
+
+            $contact = [ordered]@{
+                id = $contactId
+                workspaceId = [string](Get-ObjectValue -Object $State.workspace -Name 'id' -Default 'workspace-default')
+                accountId = if ($existing) { Get-ObjectValue -Object $existing -Name 'accountId' -Default $null } else { $null }
+                normalizedCompanyName = $normalizedCompanyName
+                companyName = $companyName
+                fullName = $fullName
+                firstName = $firstName
+                lastName = $lastName
+                title = $title
+                linkedinUrl = $linkedinUrl
+                email = $email
+                connectedOn = $connectedOn
+                yearsConnected = $yearsConnected
+                buyerFlag = $titleFlags.buyer
+                seniorFlag = $titleFlags.senior
+                talentFlag = $titleFlags.talent
+                techFlag = $titleFlags.tech
+                financeFlag = $titleFlags.finance
+                companyOverlapCount = Get-FirstResolvedNumber -Candidates @($companyContacts)
+                priorityScore = Get-FirstResolvedNumber -Candidates @($priorityScore)
+                relevanceScore = Get-FirstResolvedNumber -Candidates @($priorityScore)
+                outreachStatus = if ($existing -and (Get-ObjectValue -Object $existing -Name 'outreachStatus' -Default '')) { Get-ObjectValue -Object $existing -Name 'outreachStatus' -Default '' } else { 'not_started' }
+                notes = if ($existing -and (Get-ObjectValue -Object $existing -Name 'notes' -Default '')) { Get-ObjectValue -Object $existing -Name 'notes' -Default '' } else { '' }
+                createdAt = if ($existing -and (Get-ObjectValue -Object $existing -Name 'createdAt' -Default '')) { Get-ObjectValue -Object $existing -Name 'createdAt' -Default '' } else { (Get-Date).ToString('o') }
+                updatedAt = (Get-Date).ToString('o')
+            }
+
+            [void]$contacts.Add($contact)
+            [void]$touchedIds.Add($contactId)
+            if ($action -eq 'updated') { $stats.updated++ } else { $stats.imported++ }
+            if ($preview.Count -lt $PreviewLimit) {
+                $message = if ($connectedOnRaw -and -not $connectedOn) { 'Connected date could not be parsed and was left blank.' } else { '' }
+                [void]$preview.Add([ordered]@{
+                    rowNumber = $rowNumber
+                    action = $action
+                    fullName = $fullName
+                    companyName = $companyName
+                    title = $title
+                    email = $email
+                    linkedinUrl = $linkedinUrl
+                    connectedOn = $connectedOn
+                    message = $message
+                })
+            }
+        } catch {
+            $stats.failed++
+            if ($preview.Count -lt $PreviewLimit) {
+                [void]$preview.Add([ordered]@{
+                    rowNumber = $rowNumber
+                    action = 'failed'
+                    fullName = ''
+                    companyName = ''
+                    title = ''
+                    email = ''
+                    linkedinUrl = ''
+                    connectedOn = ''
+                    message = $_.Exception.Message
+                })
+            }
+        }
+    }
+
+    return [ordered]@{
+        contacts = @($contacts)
+        touchedIds = @($touchedIds)
+        preview = @($preview)
+        stats = $stats
+        totalRows = @($rows).Count
+    }
+}
+
 function Import-BdConnectionsCsv {
     param(
         [Parameter(Mandatory = $true)]
@@ -440,6 +812,7 @@ function Import-BdConnectionsCsv {
         [string]$SourceLabel = 'linkedin-connections-csv',
         [switch]$DryRun,
         [switch]$UseEmptyState,
+        [switch]$MergeExisting,
         [switch]$SkipPersistence,
         [scriptblock]$ProgressCallback
     )
@@ -461,6 +834,9 @@ function Import-BdConnectionsCsv {
         }
     } else {
         $state = Get-AppState
+        if ($DryRun) {
+            $state = ConvertTo-PlainObject -InputObject $state
+        }
         foreach ($collectionName in 'companies', 'contacts', 'jobs', 'boardConfigs', 'activities', 'importRuns') {
             if ($null -eq $state[$collectionName]) {
                 $state[$collectionName] = @()
@@ -468,79 +844,31 @@ function Import-BdConnectionsCsv {
         }
     }
 
-    $existingContacts = @{}
-    foreach ($contact in @($state.contacts)) {
-        $existingContacts[$contact.id] = $contact
-    }
-
     $startedAt = (Get-Date).ToString('o')
-    $rows = @(Import-Csv -LiteralPath $CsvPath)
-    $contacts = New-Object System.Collections.ArrayList
-    $totalRows = @($rows).Count
+    $plan = New-BdConnectionsCsvImportPlan -CsvPath $CsvPath -State $state
+    $totalRows = [int]$plan.totalRows
     Publish-EngineProgress -ProgressCallback $ProgressCallback -Phase 'Parsing connections CSV' -Processed 0 -Total $totalRows -StartedAt $startedAt -Message 'Normalizing LinkedIn contacts'
 
-    for ($index = 0; $index -lt $rows.Count; $index++) {
-        $row = $rows[$index]
-        $cleanCompany = if ($row.PSObject.Properties.Name -contains 'Clean Company') { $row.'Clean Company' } else { '' }
-        $companyContacts = if ($row.PSObject.Properties.Name -contains 'Company Contacts') { $row.'Company Contacts' } else { '' }
-        $priorityScore = if ($row.PSObject.Properties.Name -contains 'Priority Score') { $row.'Priority Score' } else { '' }
-        $yearsConnectedRaw = if ($row.PSObject.Properties.Name -contains 'Years Connected') { $row.'Years Connected' } else { '' }
-        $companyName = Get-CanonicalCompanyDisplayName (Get-FirstResolvedText -Candidates @($cleanCompany, $row.Company))
-        $normalizedCompanyName = Get-CanonicalCompanyKey $companyName
-        $fullName = ('{0} {1}' -f $row.'First Name', $row.'Last Name').Trim()
-        if (-not $fullName -and -not $normalizedCompanyName) {
-            continue
-        }
-
-        $title = [string]$(if ($row.PSObject.Properties.Name -contains 'Position') { $row.Position } elseif ($row.PSObject.Properties.Name -contains 'Title') { $row.Title } else { '' })
-        $titleFlags = Get-TitleFlags -Title $title
-        $connectedOn = Get-FirstResolvedDateString -Candidates @($row.'Connected On')
-        $yearsConnected = Get-FirstResolvedNumber -Candidates @($yearsConnectedRaw)
-        if ($yearsConnected -le 0 -and $connectedOn) {
-            $yearsConnected = Get-YearsConnectedFromDate -ConnectedOn $connectedOn
-        }
-
-        $linkedinUrl = [string]$(if ($row.PSObject.Properties.Name -contains 'URL') { $row.URL } elseif ($row.PSObject.Properties.Name -contains 'Profile URL') { $row.'Profile URL' } else { '' })
-        $seed = '{0}|{1}|{2}|{3}' -f $normalizedCompanyName, $fullName, $title, $linkedinUrl
-        $id = New-DeterministicId -Prefix 'con' -Seed $seed
-        $existing = $existingContacts[$id]
-
-        $contact = [ordered]@{
-            id = $id
-            workspaceId = $state.workspace.id
-            accountId = $null
-            normalizedCompanyName = $normalizedCompanyName
-            companyName = $companyName
-            fullName = $fullName
-            firstName = [string]$row.'First Name'
-            lastName = [string]$row.'Last Name'
-            title = $title
-            linkedinUrl = $linkedinUrl
-            email = [string]$(if ($row.PSObject.Properties.Name -contains 'Email Address') { $row.'Email Address' } else { '' })
-            connectedOn = $connectedOn
-            yearsConnected = $yearsConnected
-            buyerFlag = $titleFlags.buyer
-            seniorFlag = $titleFlags.senior
-            talentFlag = $titleFlags.talent
-            techFlag = $titleFlags.tech
-            financeFlag = $titleFlags.finance
-            companyOverlapCount = Get-FirstResolvedNumber -Candidates @($companyContacts)
-            priorityScore = Get-FirstResolvedNumber -Candidates @($priorityScore)
-            relevanceScore = Get-FirstResolvedNumber -Candidates @($priorityScore)
-            outreachStatus = if ($existing -and $existing.outreachStatus) { $existing.outreachStatus } else { 'not_started' }
-            notes = if ($existing -and $existing.notes) { $existing.notes } else { '' }
-            createdAt = if ($existing -and $existing.createdAt) { $existing.createdAt } else { (Get-Date).ToString('o') }
-            updatedAt = (Get-Date).ToString('o')
-        }
-        [void]$contacts.Add($contact)
-
-        $processed = $index + 1
-        if ($ProgressCallback -and ($processed -eq 1 -or $processed -eq $totalRows -or ($processed % 100) -eq 0)) {
-            Publish-EngineProgress -ProgressCallback $ProgressCallback -Phase 'Parsing connections CSV' -Processed $processed -Total $totalRows -StartedAt $startedAt -Message 'Normalizing LinkedIn contacts'
-        }
+    if ($ProgressCallback) {
+        Publish-EngineProgress -ProgressCallback $ProgressCallback -Phase 'Parsing connections CSV' -Processed $totalRows -Total $totalRows -StartedAt $startedAt -Message 'Normalizing LinkedIn contacts'
     }
 
-    $state.contacts = @($contacts)
+    if ($MergeExisting) {
+        $mergedContacts = New-Object System.Collections.ArrayList
+        foreach ($contact in @($state.contacts)) {
+            $contactId = [string](Get-ObjectValue -Object $contact -Name 'id' -Default '')
+            if (-not $contactId -or -not $plan.touchedIds.Contains($contactId)) {
+                [void]$mergedContacts.Add($contact)
+            }
+        }
+        foreach ($contact in @($plan.contacts)) {
+            [void]$mergedContacts.Add($contact)
+        }
+        $state.contacts = @($mergedContacts)
+    } else {
+        $state.contacts = @($plan.contacts)
+    }
+
     Publish-EngineProgress -ProgressCallback $ProgressCallback -Phase 'Refreshing derived data' -Processed $totalRows -Total $totalRows -StartedAt $startedAt -Message 'Recomputing target accounts from contacts'
     $state = Update-DerivedData -State $state -ProgressCallback $ProgressCallback
     $preConfigKeys = New-Object 'System.Collections.Generic.HashSet[string]'
@@ -552,7 +880,7 @@ function Import-BdConnectionsCsv {
 
     $importRun = [ordered]@{
         id = New-RandomId -Prefix 'run'
-        workspaceId = $state.workspace.id
+        workspaceId = [string](Get-ObjectValue -Object $state.workspace -Name 'id' -Default 'workspace-default')
         type = 'connections-csv-import'
         status = if ($DryRun) { 'dry_run' } else { 'completed' }
         startedAt = $startedAt
@@ -561,7 +889,17 @@ function Import-BdConnectionsCsv {
         stats = [ordered]@{
             contacts = @($state.contacts).Count
             companies = @($state.companies).Count
+            rows = [int]$plan.stats.rows
+            imported = [int]$plan.stats.imported
+            updated = [int]$plan.stats.updated
+            skipped = [int]$plan.stats.skipped
+            failed = [int]$plan.stats.failed
             source = $SourceLabel
+        }
+        metadata = [ordered]@{
+            dedupeKeys = @('linkedinUrl', 'email', 'name+company')
+            mergeExisting = [bool]$MergeExisting
+            previewCount = @($plan.preview).Count
         }
         errors = @()
     }
@@ -576,6 +914,7 @@ function Import-BdConnectionsCsv {
     return [ordered]@{
         state = $state
         importRun = $importRun
+        preview = @($plan.preview)
     }
 }
 

--- a/server/Modules/BdEngine.JobImport.psm1
+++ b/server/Modules/BdEngine.JobImport.psm1
@@ -920,8 +920,8 @@ function New-GeneratedBoardConfig {
     $id = New-DeterministicId -Prefix 'cfgauto' -Seed $normalizedName
     return [ordered]@{
         id = $id
-        workspaceId = $State.workspace.id
-        accountId = $Company.id
+        workspaceId = [string](Get-ObjectValue -Object $State.workspace -Name 'id' -Default 'workspace-default')
+        accountId = [string](Get-ObjectValue -Object $Company -Name 'id' -Default '')
         companyName = $companyName
         normalizedCompanyName = $normalizedName
         atsType = [string]$template.atsType
@@ -5692,14 +5692,18 @@ function Sync-BoardConfigsFromCompanies {
     $existingByCompany = @{}
     $companyKeySet = New-Object 'System.Collections.Generic.HashSet[string]'
     foreach ($company in @($State.companies)) {
-        $companyKey = Get-CanonicalCompanyKey $(if ($company.normalizedName) { $company.normalizedName } else { $company.displayName })
+        $normalizedName = [string](Get-ObjectValue -Object $company -Name 'normalizedName' -Default '')
+        $displayName = [string](Get-ObjectValue -Object $company -Name 'displayName' -Default '')
+        $companyKey = Get-CanonicalCompanyKey $(if ($normalizedName) { $normalizedName } else { $displayName })
         if ($companyKey) {
             [void]$companyKeySet.Add($companyKey)
         }
     }
 
     foreach ($config in @($State.boardConfigs)) {
-        $key = Get-CanonicalCompanyKey $(if ($config.normalizedCompanyName) { $config.normalizedCompanyName } else { $config.companyName })
+        $normalizedCompanyName = [string](Get-ObjectValue -Object $config -Name 'normalizedCompanyName' -Default '')
+        $companyName = [string](Get-ObjectValue -Object $config -Name 'companyName' -Default '')
+        $key = Get-CanonicalCompanyKey $(if ($normalizedCompanyName) { $normalizedCompanyName } else { $companyName })
         if (-not $key) {
             continue
         }
@@ -5721,14 +5725,14 @@ function Sync-BoardConfigsFromCompanies {
             continue
         }
 
-        $key = $generated.normalizedCompanyName
+        $key = [string](Get-ObjectValue -Object $generated -Name 'normalizedCompanyName' -Default '')
         $existingItems = if ($existingByCompany.ContainsKey($key)) { @($existingByCompany[$key].ToArray()) } else { @() }
         $manualItems = @($existingItems | Where-Object { ([string](Get-ObjectValue -Object $_ -Name 'source' -Default '')).ToLowerInvariant() -eq 'manual' -or ([string](Get-ObjectValue -Object $_ -Name 'discoveryMethod' -Default '')).ToLowerInvariant() -eq 'manual' })
 
         if ($manualItems.Count -gt 0) {
             foreach ($item in $existingItems) {
-                [void](Set-ObjectValue -Object $item -Name 'accountId' -Value $company.id)
-                [void](Set-ObjectValue -Object $item -Name 'companyName' -Value $company.displayName)
+                [void](Set-ObjectValue -Object $item -Name 'accountId' -Value (Get-ObjectValue -Object $company -Name 'id' -Default ''))
+                [void](Set-ObjectValue -Object $item -Name 'companyName' -Value (Get-ObjectValue -Object $company -Name 'displayName' -Default ''))
                 [void](Set-ObjectValue -Object $item -Name 'normalizedCompanyName' -Value $key)
                 $itemDomain = [string](Get-ObjectValue -Object $item -Name 'domain')
                 $itemLastCheckedAt = [string](Get-ObjectValue -Object $item -Name 'lastCheckedAt')
@@ -5771,7 +5775,9 @@ function Sync-BoardConfigsFromCompanies {
     }
 
     foreach ($config in @($State.boardConfigs)) {
-        $key = Get-CanonicalCompanyKey $(if ($config.normalizedCompanyName) { $config.normalizedCompanyName } else { $config.companyName })
+        $normalizedCompanyName = [string](Get-ObjectValue -Object $config -Name 'normalizedCompanyName' -Default '')
+        $companyName = [string](Get-ObjectValue -Object $config -Name 'companyName' -Default '')
+        $key = Get-CanonicalCompanyKey $(if ($normalizedCompanyName) { $normalizedCompanyName } else { $companyName })
         if ($key -and $companyKeySet.Contains($key)) {
             continue
         }

--- a/server/Modules/BdEngine.JobImport.psm1
+++ b/server/Modules/BdEngine.JobImport.psm1
@@ -909,8 +909,9 @@ function New-GeneratedBoardConfig {
         $template.confidenceScore = if (Test-ObjectHasKey -Object $template -Name 'confidenceScore' | Where-Object { $_ }) { Get-ObjectValue -Object $template -Name 'confidenceScore' } else { 100 }
         $template.confidenceBand = 'high'
         $template.supportedImport = [bool](Test-ImportCapableAtsType -AtsType ([string]$template.atsType))
-        $template.active = [bool]($template.supportedImport -and $template.active)
-        $template.reviewStatus = if ($template.reviewStatus) { $template.reviewStatus } else { 'auto' }
+        $template.active = [bool]($template.supportedImport -and (Test-Truthy (Get-ObjectValue -Object $template -Name 'active' -Default $true)))
+        $templateReviewStatus = [string](Get-ObjectValue -Object $template -Name 'reviewStatus' -Default '')
+        $template.reviewStatus = if ($templateReviewStatus) { $templateReviewStatus } else { 'auto' }
     } elseif ($templateDiscoveryStatus -eq 'verified') {
         $template.discoveryStatus = 'discovered'
     } elseif ($templateDiscoveryStatus -eq 'unresolved') {

--- a/server/Modules/BdEngine.JobImport.psm1
+++ b/server/Modules/BdEngine.JobImport.psm1
@@ -908,7 +908,7 @@ function New-GeneratedBoardConfig {
         $template.discoveryStatus = 'mapped'
         $template.confidenceScore = if (Test-ObjectHasKey -Object $template -Name 'confidenceScore' | Where-Object { $_ }) { Get-ObjectValue -Object $template -Name 'confidenceScore' } else { 100 }
         $template.confidenceBand = 'high'
-        $template.supportedImport = [bool](Test-ImportCapableAtsType -AtsType ([string]$template.atsType))
+        $template.supportedImport = [bool](Test-ImportCapableAtsType -AtsType ([string](Get-ObjectValue -Object $template -Name 'atsType' -Default '')))
         $template.active = [bool]($template.supportedImport -and (Test-Truthy (Get-ObjectValue -Object $template -Name 'active' -Default $true)))
         $templateReviewStatus = [string](Get-ObjectValue -Object $template -Name 'reviewStatus' -Default '')
         $template.reviewStatus = if ($templateReviewStatus) { $templateReviewStatus } else { 'auto' }
@@ -919,28 +919,37 @@ function New-GeneratedBoardConfig {
     }
 
     $id = New-DeterministicId -Prefix 'cfgauto' -Seed $normalizedName
+    $templateAtsType = [string](Get-ObjectValue -Object $template -Name 'atsType' -Default '')
+    $templateBoardId = [string](Get-ObjectValue -Object $template -Name 'boardId' -Default '')
+    $templateDomain = [string](Get-ObjectValue -Object $template -Name 'domain' -Default '')
+    $templateCareersUrl = [string](Get-ObjectValue -Object $template -Name 'careersUrl' -Default '')
+    $templateResolvedBoardUrl = [string](Get-ObjectValue -Object $template -Name 'resolvedBoardUrl' -Default '')
+    $templateDiscoveryStatus = [string](Get-ObjectValue -Object $template -Name 'discoveryStatus' -Default 'missing_inputs')
+    $templateDiscoveryMethod = [string](Get-ObjectValue -Object $template -Name 'discoveryMethod' -Default '')
+    $templateConfidenceScore = [double]$(if (Test-ObjectHasKey -Object $template -Name 'confidenceScore') { Get-ObjectValue -Object $template -Name 'confidenceScore' } else { 0 })
+    $templateConfidenceBand = [string]$(if (Get-ObjectValue -Object $template -Name 'confidenceBand') { Get-ObjectValue -Object $template -Name 'confidenceBand' } else { Get-ResolverConfidenceBand -Score $templateConfidenceScore })
     return [ordered]@{
         id = $id
         workspaceId = [string](Get-ObjectValue -Object $State.workspace -Name 'id' -Default 'workspace-default')
         accountId = [string](Get-ObjectValue -Object $Company -Name 'id' -Default '')
         companyName = $companyName
         normalizedCompanyName = $normalizedName
-        atsType = [string]$template.atsType
-        boardId = [string]$template.boardId
-        domain = [string]$template.domain
-        careersUrl = [string]$template.careersUrl
-        resolvedBoardUrl = [string]$(if ($template.resolvedBoardUrl) { $template.resolvedBoardUrl } else { '' })
-        source = [string]$template.source
-        notes = [string]$template.notes
-        active = if ($null -ne $template.active) { [bool]$template.active } else { $true }
-        supportedImport = [bool]$(if (Test-ObjectHasKey -Object $template -Name 'supportedImport') { Get-ObjectValue -Object $template -Name 'supportedImport' } else { Test-ImportCapableAtsType -AtsType ([string]$template.atsType) })
-        lastCheckedAt = if ($template.discoveryStatus -in @('mapped', 'discovered')) { (Get-Date).ToString('o') } else { $null }
+        atsType = $templateAtsType
+        boardId = $templateBoardId
+        domain = $templateDomain
+        careersUrl = $templateCareersUrl
+        resolvedBoardUrl = $templateResolvedBoardUrl
+        source = [string](Get-ObjectValue -Object $template -Name 'source' -Default '')
+        notes = [string](Get-ObjectValue -Object $template -Name 'notes' -Default '')
+        active = if (Test-ObjectHasKey -Object $template -Name 'active') { [bool](Test-Truthy (Get-ObjectValue -Object $template -Name 'active' -Default $true)) } else { $true }
+        supportedImport = [bool]$(if (Test-ObjectHasKey -Object $template -Name 'supportedImport') { Get-ObjectValue -Object $template -Name 'supportedImport' } else { Test-ImportCapableAtsType -AtsType $templateAtsType })
+        lastCheckedAt = if ($templateDiscoveryStatus -in @('mapped', 'discovered')) { (Get-Date).ToString('o') } else { $null }
         lastResolutionAttemptAt = $null
         nextResolutionAttemptAt = $null
-        discoveryStatus = [string]$template.discoveryStatus
-        discoveryMethod = [string]$template.discoveryMethod
-        confidenceScore = [double]$(if (Test-ObjectHasKey -Object $template -Name 'confidenceScore') { Get-ObjectValue -Object $template -Name 'confidenceScore' } else { 0 })
-        confidenceBand = [string]$(if (Get-ObjectValue -Object $template -Name 'confidenceBand') { Get-ObjectValue -Object $template -Name 'confidenceBand' } else { Get-ResolverConfidenceBand -Score ([double]$(if (Test-ObjectHasKey -Object $template -Name 'confidenceScore') { Get-ObjectValue -Object $template -Name 'confidenceScore' } else { 0 })) })
+        discoveryStatus = $templateDiscoveryStatus
+        discoveryMethod = $templateDiscoveryMethod
+        confidenceScore = $templateConfidenceScore
+        confidenceBand = $templateConfidenceBand
         evidenceSummary = [string]$(if (Get-ObjectValue -Object $template -Name 'evidenceSummary') { Get-ObjectValue -Object $template -Name 'evidenceSummary' } else { '' })
         reviewStatus = [string]$(if (Get-ObjectValue -Object $template -Name 'reviewStatus') { Get-ObjectValue -Object $template -Name 'reviewStatus' } else { 'pending' })
         failureReason = [string]$(if (Get-ObjectValue -Object $template -Name 'failureReason') { Get-ObjectValue -Object $template -Name 'failureReason' } else { '' })
@@ -5226,23 +5235,25 @@ function Get-DiscoveryResultForConfig {
             }
         }
         if ($knownTemplate) {
-            Write-PipelineDiag -Stage 'discovery_known_map' -Company $companyName -Message 'Matched known template map' -Data @{ atsType = [string]$knownTemplate.atsType; boardId = [string]$knownTemplate.boardId }
-            $knownAtsType = [string]$knownTemplate.atsType
-            $knownBoardId = [string]$knownTemplate.boardId
+            $knownAtsType = [string](Get-ObjectValue -Object $knownTemplate -Name 'atsType' -Default '')
+            $knownBoardId = [string](Get-ObjectValue -Object $knownTemplate -Name 'boardId' -Default '')
+            $knownDomain = [string](Get-ObjectValue -Object $knownTemplate -Name 'domain' -Default '')
+            $knownCareersUrl = [string](Get-ObjectValue -Object $knownTemplate -Name 'careersUrl' -Default '')
+            Write-PipelineDiag -Stage 'discovery_known_map' -Company $companyName -Message 'Matched known template map' -Data @{ atsType = $knownAtsType; boardId = $knownBoardId }
             $supportedImport = [bool]$(if (Test-ObjectHasKey -Object $knownTemplate -Name 'supportedImport') { Get-ObjectValue -Object $knownTemplate -Name 'supportedImport' } else { Test-ImportCapableAtsType -AtsType $knownAtsType })
-            $resolvedBoardUrl = [string]$(if (Get-ObjectValue -Object $knownTemplate -Name 'resolvedBoardUrl') { Get-ObjectValue -Object $knownTemplate -Name 'resolvedBoardUrl' } else { Get-ResolvedBoardUrl -AtsType $knownAtsType -BoardId $knownBoardId -FallbackUrl ([string]$(if ($knownTemplate.careersUrl) { $knownTemplate.careersUrl } else { $careersUrl })) })
+            $resolvedBoardUrl = [string]$(if (Get-ObjectValue -Object $knownTemplate -Name 'resolvedBoardUrl') { Get-ObjectValue -Object $knownTemplate -Name 'resolvedBoardUrl' } else { Get-ResolvedBoardUrl -AtsType $knownAtsType -BoardId $knownBoardId -FallbackUrl ([string]$(if ($knownCareersUrl) { $knownCareersUrl } else { $careersUrl })) })
             return [ordered]@{
                 atsType = $knownAtsType
                 boardId = $knownBoardId
-                domain = [string]$(if ($knownTemplate.domain) { $knownTemplate.domain } else { $resolvedDomain })
-                careersUrl = [string]$(if ($knownTemplate.careersUrl) { $knownTemplate.careersUrl } else { $resolvedCareersUrl })
+                domain = [string]$(if ($knownDomain) { $knownDomain } else { $resolvedDomain })
+                careersUrl = [string]$(if ($knownCareersUrl) { $knownCareersUrl } else { $resolvedCareersUrl })
                 resolvedBoardUrl = $resolvedBoardUrl
-                source = [string]$knownTemplate.source
+                source = [string](Get-ObjectValue -Object $knownTemplate -Name 'source' -Default '')
                 notes = 'Matched from known mapping'
-                active = [bool]($supportedImport -and $(if (Test-ObjectHasKey -Object $knownTemplate -Name 'active') { $knownTemplate.active } else { $true }))
+                active = [bool]($supportedImport -and $(if (Test-ObjectHasKey -Object $knownTemplate -Name 'active') { Test-Truthy (Get-ObjectValue -Object $knownTemplate -Name 'active' -Default $true) } else { $true }))
                 supportedImport = $supportedImport
                 discoveryStatus = 'mapped'
-                discoveryMethod = [string]$(if ($knownTemplate.discoveryMethod) { $knownTemplate.discoveryMethod } else { 'known_map' })
+                discoveryMethod = [string]$(if (Get-ObjectValue -Object $knownTemplate -Name 'discoveryMethod') { Get-ObjectValue -Object $knownTemplate -Name 'discoveryMethod' } else { 'known_map' })
                 confidenceScore = 100
                 confidenceBand = 'high'
                 evidenceSummary = 'Explicit known mapping'
@@ -5265,8 +5276,8 @@ function Get-DiscoveryResultForConfig {
                 $verifiedAtsType = [string]$(if ($verified) { Get-ObjectValue -Object $verified -Name 'atsType' } else { '' })
                 if ($verified -and $verifiedAtsType) {
                     $bestCandidate = $verified
-                    $bestCandidate.domain = if ($resolvedDomain) { $resolvedDomain } else { $verified.domain }
-                    $bestCandidate.careersUrl = if ($resolvedCareersUrl) { $resolvedCareersUrl } else { $verified.careersUrl }
+                    $bestCandidate.domain = if ($resolvedDomain) { $resolvedDomain } else { Get-ObjectValue -Object $verified -Name 'domain' -Default '' }
+                    $bestCandidate.careersUrl = if ($resolvedCareersUrl) { $resolvedCareersUrl } else { Get-ObjectValue -Object $verified -Name 'careersUrl' -Default '' }
                     $bestCandidate.evidenceSummary = 'Careers URL matched a hosted ATS board and the public endpoint responded'
                 } elseif ($verified -and (Test-ObjectHasKey -Object $verified -Name 'httpSummary')) {
                     foreach ($attempt in @((Get-ObjectValue -Object $verified -Name 'httpSummary'))) { [void]$httpSummary.Add($attempt) }

--- a/server/Modules/BdEngine.SqliteStore.psm1
+++ b/server/Modules/BdEngine.SqliteStore.psm1
@@ -57,8 +57,12 @@ function Get-BdSqliteDatabaseFileStamp {
             continue
         }
 
-        $item = Get-Item -LiteralPath $path
-        [void]$stampParts.Add(('{0}:{1}:{2}' -f $path, $item.LastWriteTimeUtc.Ticks, $item.Length))
+        $item = @(Get-Item -LiteralPath $path -ErrorAction SilentlyContinue) | Select-Object -First 1
+        if ($item -and $item.PSObject.Properties['LastWriteTimeUtc']) {
+            [void]$stampParts.Add(('{0}:{1}:{2}' -f $path, $item.LastWriteTimeUtc.Ticks, $item.Length))
+        } else {
+            [void]$stampParts.Add(('{0}:unavailable:0' -f $path))
+        }
     }
 
     return [string]::Join('|', @($stampParts))

--- a/server/Modules/BdEngine.SqliteStore.psm1
+++ b/server/Modules/BdEngine.SqliteStore.psm1
@@ -248,7 +248,17 @@ function Get-BdSqliteRecordValue {
     }
 
     if ($Record -is [System.Collections.IDictionary]) {
-        if ($Record.Contains($Name)) {
+        $hasKey = $false
+        if ($Record.PSObject.Methods.Name -contains 'ContainsKey') {
+            $hasKey = $Record.ContainsKey($Name)
+        } else {
+            try {
+                $hasKey = $Record.Contains($Name)
+            } catch {
+                $hasKey = $false
+            }
+        }
+        if ($hasKey) {
             return $Record[$Name]
         }
         return $Default

--- a/server/Modules/BdEngine.State.psm1
+++ b/server/Modules/BdEngine.State.psm1
@@ -12,6 +12,34 @@ function Test-AppStoreUsesSqlite {
     return (Test-BdSqliteStoreEnabled)
 }
 
+function Test-AppRecordHasKey {
+    param(
+        $Record,
+        [string]$Name
+    )
+
+    if ($null -eq $Record -or [string]::IsNullOrWhiteSpace($Name)) {
+        return $false
+    }
+
+    if ($Record -is [System.Collections.Generic.Dictionary[string, object]]) {
+        return $Record.ContainsKey($Name)
+    }
+
+    if ($Record -is [System.Collections.IDictionary]) {
+        if ($Record.PSObject.Methods.Name -contains 'ContainsKey') {
+            return $Record.ContainsKey($Name)
+        }
+        try {
+            return $Record.Contains($Name)
+        } catch {
+            return $false
+        }
+    }
+
+    return [bool]$Record.PSObject.Properties[$Name]
+}
+
 function Get-JsonSerializer {
     if (-not ('System.Web.Script.Serialization.JavaScriptSerializer' -as [type])) {
         Add-Type -AssemblyName System.Web.Extensions
@@ -193,12 +221,7 @@ function Test-CollectionHasFields {
         $item = $Items[$index]
         foreach ($field in $Fields) {
             if ($item -is [System.Collections.IDictionary]) {
-                $hasField = $false
-                if ($item -is [System.Collections.Generic.Dictionary[string, object]]) {
-                    $hasField = $item.ContainsKey($field)
-                } else {
-                    $hasField = $item.Contains($field)
-                }
+                $hasField = Test-AppRecordHasKey -Record $item -Name $field
 
                 if (-not $hasField) {
                     return $false
@@ -221,12 +244,7 @@ function Ensure-RecordDefaults {
     )
 
     foreach ($key in @($Defaults.Keys)) {
-        $hasKey = $false
-        if ($Record -is [System.Collections.Generic.Dictionary[string, object]]) {
-            $hasKey = $Record.ContainsKey($key)
-        } else {
-            $hasKey = $Record.Contains($key)
-        }
+        $hasKey = Test-AppRecordHasKey -Record $Record -Name $key
 
         if (-not $hasKey) {
             $Record[$key] = Get-DefaultClone -Default $Defaults[$key]

--- a/server/Modules/BdEngine.State.psm1
+++ b/server/Modules/BdEngine.State.psm1
@@ -63,8 +63,12 @@ function Get-StorageSignature {
 
     foreach ($path in @($map.Values)) {
         if (Test-Path -LiteralPath $path) {
-            $item = Get-Item -LiteralPath $path
-            [void]$parts.Add(('{0}:{1}' -f $path, $item.LastWriteTimeUtc.Ticks))
+            $item = @(Get-Item -LiteralPath $path -ErrorAction SilentlyContinue) | Select-Object -First 1
+            if ($item -and $item.PSObject.Properties['LastWriteTimeUtc']) {
+                [void]$parts.Add(('{0}:{1}' -f $path, $item.LastWriteTimeUtc.Ticks))
+            } else {
+                [void]$parts.Add(('{0}:unavailable' -f $path))
+            }
         } else {
             [void]$parts.Add(('{0}:missing' -f $path))
         }
@@ -87,8 +91,11 @@ function Get-SegmentStorageSignature {
     $map = Get-StorageMap
     $path = $map[$Segment]
     if (Test-Path -LiteralPath $path) {
-        $item = Get-Item -LiteralPath $path
-        return '{0}:{1}' -f $path, $item.LastWriteTimeUtc.Ticks
+        $item = @(Get-Item -LiteralPath $path -ErrorAction SilentlyContinue) | Select-Object -First 1
+        if ($item -and $item.PSObject.Properties['LastWriteTimeUtc']) {
+            return '{0}:{1}' -f $path, $item.LastWriteTimeUtc.Ticks
+        }
+        return '{0}:unavailable' -f $path
     }
 
     return '{0}:missing' -f $path

--- a/server/Server.ps1
+++ b/server/Server.ps1
@@ -728,7 +728,7 @@ function Get-ConfigResults {
     if ($Query.ats) { $items = @($items | Where-Object { $_.atsType -eq $Query.ats }) }
     if ($Query.discoveryStatus) { $items = @($items | Where-Object { $_.discoveryStatus -eq $Query.discoveryStatus }) }
     if ($Query.confidenceBand) { $items = @($items | Where-Object { ([string]$(if ($_.confidenceBand) { $_.confidenceBand } else { 'unresolved' })) -eq $Query.confidenceBand }) }
-    if ($Query.reviewStatus) { $items = @($items | Where-Object { ([string]$(if ($_.reviewStatus) { $_.reviewStatus } else { 'pending' })) -eq $Query.reviewStatus }) }
+    if ($Query.reviewStatus) { $items = @($items | Where-Object { ([string](Get-ObjectValue -Object $_ -Name 'reviewStatus' -Default 'pending')) -eq $Query.reviewStatus }) }
     if ($Query.active) {
         $want = Test-Truthy $Query.active
         $items = @($items | Where-Object { (Test-Truthy $_.active) -eq $want })
@@ -1532,8 +1532,8 @@ function Handle-ApiRequest {
                         unresolvedCount = [int][Math]::Max(0, $total - $resolved)
                         activeCount = @($configs | Where-Object { $_.active }).Count
                         coveragePercent = if ($total -gt 0) { [double][Math]::Round(($resolved / $total) * 100, 1) } else { 0 }
-                        mediumReviewQueueCount = @($configs | Where-Object { $_.confidenceBand -eq 'medium' -and ([string]$(if ($_.reviewStatus) { $_.reviewStatus } else { 'pending' })) -eq 'pending' }).Count
-                        unresolvedReviewQueueCount = @($configs | Where-Object { ([string]$(if ($_.confidenceBand) { $_.confidenceBand } else { 'unresolved' })) -eq 'unresolved' -and ([string]$(if ($_.reviewStatus) { $_.reviewStatus } else { 'pending' })) -ne 'rejected' }).Count
+                        mediumReviewQueueCount = @($configs | Where-Object { ([string](Get-ObjectValue -Object $_ -Name 'confidenceBand' -Default 'unresolved')) -eq 'medium' -and ([string](Get-ObjectValue -Object $_ -Name 'reviewStatus' -Default 'pending')) -eq 'pending' }).Count
+                        unresolvedReviewQueueCount = @($configs | Where-Object { ([string](Get-ObjectValue -Object $_ -Name 'confidenceBand' -Default 'unresolved')) -eq 'unresolved' -and ([string](Get-ObjectValue -Object $_ -Name 'reviewStatus' -Default 'pending')) -ne 'rejected' }).Count
                     }
                     byAtsType = @()
                     byConfidenceBand = @()

--- a/server/Server.ps1
+++ b/server/Server.ps1
@@ -1041,35 +1041,34 @@ function Handle-ApiRequest {
             }) | Out-Null
         }
 
-        $importResult = $null
+        $acceptedImport = $null
         $csvContent = [string](Get-ObjectValue -Object $payload -Name 'csvContent' -Default '')
-        $tempFile = ''
-        try {
-            if (-not [string]::IsNullOrWhiteSpace($csvContent)) {
-                $tempFile = Join-Path $env:TEMP ("bd-setup-linkedin-" + [System.Guid]::NewGuid().ToString('N') + ".csv")
-                [System.IO.File]::WriteAllText($tempFile, $csvContent, [System.Text.Encoding]::UTF8)
-                $importResult = Import-BdConnectionsCsv -CsvPath $tempFile -SourceLabel 'setup-linkedin-connections-csv' -MergeExisting -SkipPersistence
-                $state = $importResult.state
-            }
 
-            Set-ObjectValue -Object $state -Name 'workspace' -Value $workspace | Out-Null
-            Set-ObjectValue -Object $state -Name 'settings' -Value $settings | Out-Null
-            $segments = @('Workspace', 'Settings')
-            if ($importResult) {
-                $segments += @('Contacts', 'Companies', 'BoardConfigs', 'ImportRuns')
-            }
-            Sync-AppStateSegments -State $state -Segments $segments | Out-Null
-        } finally {
-            if ($tempFile -and (Test-Path -LiteralPath $tempFile)) {
-                Remove-Item -LiteralPath $tempFile -Force -ErrorAction SilentlyContinue
-            }
+        Set-ObjectValue -Object $state -Name 'workspace' -Value $workspace | Out-Null
+        Set-ObjectValue -Object $state -Name 'settings' -Value $settings | Out-Null
+        Sync-AppStateSegments -State $state -Segments @('Workspace', 'Settings') | Out-Null
+
+        if (-not [string]::IsNullOrWhiteSpace($csvContent)) {
+            $tempFile = Join-Path $env:TEMP ("bd-setup-linkedin-" + [System.Guid]::NewGuid().ToString('N') + ".csv")
+            [System.IO.File]::WriteAllText($tempFile, $csvContent, [System.Text.Encoding]::UTF8)
+            $job = Enqueue-BackgroundJob -Type 'connections-csv-import' -Payload ([ordered]@{
+                csvPath = $tempFile
+                isTempFile = $true
+                mergeExisting = $true
+                sourceLabel = 'setup-linkedin-connections-csv'
+            }) -Summary 'Import LinkedIn connections from setup' -ProgressMessage 'Queued LinkedIn connections import'
+            Write-ServerLog ("JOB enqueue id={0} type={1} source={2}" -f $job.id, $job.type, 'setup')
+            $acceptedImport = Get-BackgroundJobAcceptedResult -Job $job
         }
 
         return (New-JsonResult ([ordered]@{
             status = Get-SetupStatus
-            importRun = if ($importResult) { $importResult.importRun } else { $null }
-            stats = if ($importResult) { $importResult.importRun.stats } else { [ordered]@{ contacts = 0; companies = 0; imported = 0; updated = 0; skipped = 0; failed = 0 } }
-            preview = if ($importResult) { @($importResult.preview) } else { @() }
+            importQueued = [bool]$acceptedImport
+            jobId = if ($acceptedImport) { $acceptedImport.jobId } else { $null }
+            job = if ($acceptedImport) { $acceptedImport.job } else { $null }
+            importRun = $null
+            stats = [ordered]@{ contacts = 0; companies = 0; imported = 0; updated = 0; skipped = 0; failed = 0 }
+            preview = @()
         }) 200)
     }
     if ($path -eq '/api/background-jobs' -and $method -eq 'GET') {

--- a/server/Server.ps1
+++ b/server/Server.ps1
@@ -2053,7 +2053,7 @@ function Handle-ApiRequest {
         $payload = Read-JsonBody -Request $Request
         $spreadsheetId = if ($payload.spreadsheetId) { [string]$payload.spreadsheetId } elseif ($env:GOOGLE_SHEETS_SPREADSHEET_ID) { [string]$env:GOOGLE_SHEETS_SPREADSHEET_ID } else { '' }
         if (-not $spreadsheetId) {
-            return (New-JsonResult ([ordered]@{ error = 'spreadsheetId is required' }) 400)
+            return (New-JsonResult ([ordered]@{ error = 'Run Full Engine requires a Google Sheets Spreadsheet ID. Enter one in Admin > Google Sheets before running the legacy sheet pipeline.' }) 400)
         }
         return (New-JsonResult (Test-GoogleSheetsAccess -SpreadsheetId $spreadsheetId) 200)
     }

--- a/server/Server.ps1
+++ b/server/Server.ps1
@@ -1049,7 +1049,7 @@ function Handle-ApiRequest {
             $setupCsvPath = Join-Path $env:TEMP ("bd-setup-linkedin-" + [System.Guid]::NewGuid().ToString('N') + ".csv")
             [System.IO.File]::WriteAllText($setupCsvPath, $csvContent, [System.Text.Encoding]::UTF8)
             try {
-                $validation = Import-BdConnectionsCsv -CsvPath $setupCsvPath -DryRun -MergeExisting
+                $validation = Get-BdConnectionsCsvPreview -CsvPath $setupCsvPath -MergeExisting -SourceLabel 'setup-linkedin-connections-csv'
                 $validationStats = $validation.importRun.stats
                 $actionableRows = [int](Get-ObjectValue -Object $validationStats -Name 'imported' -Default 0) + [int](Get-ObjectValue -Object $validationStats -Name 'updated' -Default 0)
                 if ($actionableRows -le 0) {
@@ -2007,9 +2007,8 @@ function Handle-ApiRequest {
         }
 
         try {
-            $result = Import-BdConnectionsCsv `
+            $result = Get-BdConnectionsCsvPreview `
                 -CsvPath $csvPath `
-                -DryRun `
                 -MergeExisting `
                 -UseEmptyState:(Test-Truthy (Get-ObjectValue -Object $payload -Name 'useEmptyState' -Default $false))
             return (New-JsonResult ([ordered]@{
@@ -2048,9 +2047,8 @@ function Handle-ApiRequest {
             return (New-JsonResult ([ordered]@{ error = "CSV file not found: $csvPath" }) 400)
         }
         if (Test-Truthy $payload.dryRun) {
-            $result = Import-BdConnectionsCsv `
+            $result = Get-BdConnectionsCsvPreview `
                 -CsvPath $csvPath `
-                -DryRun:(Test-Truthy $payload.dryRun) `
                 -MergeExisting `
                 -UseEmptyState:(Test-Truthy $payload.useEmptyState)
             if ($isTempFile -and (Test-Path -LiteralPath $csvPath)) {
@@ -2060,7 +2058,7 @@ function Handle-ApiRequest {
         }
 
         try {
-            $validation = Import-BdConnectionsCsv -CsvPath $csvPath -DryRun -MergeExisting
+            $validation = Get-BdConnectionsCsvPreview -CsvPath $csvPath -MergeExisting -SourceLabel 'linkedin-connections-csv'
             $validationStats = $validation.importRun.stats
             $actionableRows = [int](Get-ObjectValue -Object $validationStats -Name 'imported' -Default 0) + [int](Get-ObjectValue -Object $validationStats -Name 'updated' -Default 0)
             if ($actionableRows -le 0) {

--- a/server/Server.ps1
+++ b/server/Server.ps1
@@ -1043,16 +1043,40 @@ function Handle-ApiRequest {
 
         $acceptedImport = $null
         $csvContent = [string](Get-ObjectValue -Object $payload -Name 'csvContent' -Default '')
+        $setupCsvPath = ''
+
+        if (-not [string]::IsNullOrWhiteSpace($csvContent)) {
+            $setupCsvPath = Join-Path $env:TEMP ("bd-setup-linkedin-" + [System.Guid]::NewGuid().ToString('N') + ".csv")
+            [System.IO.File]::WriteAllText($setupCsvPath, $csvContent, [System.Text.Encoding]::UTF8)
+            try {
+                $validation = Import-BdConnectionsCsv -CsvPath $setupCsvPath -DryRun -MergeExisting
+                $validationStats = $validation.importRun.stats
+                $actionableRows = [int](Get-ObjectValue -Object $validationStats -Name 'imported' -Default 0) + [int](Get-ObjectValue -Object $validationStats -Name 'updated' -Default 0)
+                if ($actionableRows -le 0) {
+                    if (Test-Path -LiteralPath $setupCsvPath) {
+                        Remove-Item -LiteralPath $setupCsvPath -Force -ErrorAction SilentlyContinue
+                    }
+                    return (New-JsonResult ([ordered]@{
+                        error = 'No LinkedIn connection rows were found. Choose the unzipped Connections.csv export from LinkedIn with headers like First Name, Last Name, URL, Email Address, Company, Position, and Connected On.'
+                        stats = $validationStats
+                        preview = @($validation.preview)
+                    }) 400)
+                }
+            } catch {
+                if (Test-Path -LiteralPath $setupCsvPath) {
+                    Remove-Item -LiteralPath $setupCsvPath -Force -ErrorAction SilentlyContinue
+                }
+                return (New-JsonResult ([ordered]@{ error = "LinkedIn Connections.csv could not be read: $($_.Exception.Message)" }) 400)
+            }
+        }
 
         Set-ObjectValue -Object $state -Name 'workspace' -Value $workspace | Out-Null
         Set-ObjectValue -Object $state -Name 'settings' -Value $settings | Out-Null
         Sync-AppStateSegments -State $state -Segments @('Workspace', 'Settings') | Out-Null
 
         if (-not [string]::IsNullOrWhiteSpace($csvContent)) {
-            $tempFile = Join-Path $env:TEMP ("bd-setup-linkedin-" + [System.Guid]::NewGuid().ToString('N') + ".csv")
-            [System.IO.File]::WriteAllText($tempFile, $csvContent, [System.Text.Encoding]::UTF8)
             $job = Enqueue-BackgroundJob -Type 'connections-csv-import' -Payload ([ordered]@{
-                csvPath = $tempFile
+                csvPath = $setupCsvPath
                 isTempFile = $true
                 mergeExisting = $true
                 sourceLabel = 'setup-linkedin-connections-csv'
@@ -2027,6 +2051,7 @@ function Handle-ApiRequest {
             $result = Import-BdConnectionsCsv `
                 -CsvPath $csvPath `
                 -DryRun:(Test-Truthy $payload.dryRun) `
+                -MergeExisting `
                 -UseEmptyState:(Test-Truthy $payload.useEmptyState)
             if ($isTempFile -and (Test-Path -LiteralPath $csvPath)) {
                 Remove-Item -LiteralPath $csvPath -Force -ErrorAction SilentlyContinue
@@ -2034,9 +2059,32 @@ function Handle-ApiRequest {
             return (New-JsonResult $result.importRun 201)
         }
 
+        try {
+            $validation = Import-BdConnectionsCsv -CsvPath $csvPath -DryRun -MergeExisting
+            $validationStats = $validation.importRun.stats
+            $actionableRows = [int](Get-ObjectValue -Object $validationStats -Name 'imported' -Default 0) + [int](Get-ObjectValue -Object $validationStats -Name 'updated' -Default 0)
+            if ($actionableRows -le 0) {
+                if ($isTempFile -and (Test-Path -LiteralPath $csvPath)) {
+                    Remove-Item -LiteralPath $csvPath -Force -ErrorAction SilentlyContinue
+                }
+                return (New-JsonResult ([ordered]@{
+                    error = 'No LinkedIn connection rows were found. Choose the unzipped Connections.csv export from LinkedIn with headers like First Name, Last Name, URL, Email Address, Company, Position, and Connected On.'
+                    stats = $validationStats
+                    preview = @($validation.preview)
+                }) 400)
+            }
+        } catch {
+            if ($isTempFile -and (Test-Path -LiteralPath $csvPath)) {
+                Remove-Item -LiteralPath $csvPath -Force -ErrorAction SilentlyContinue
+            }
+            return (New-JsonResult ([ordered]@{ error = "LinkedIn Connections.csv could not be read: $($_.Exception.Message)" }) 400)
+        }
+
         $job = Enqueue-BackgroundJob -Type 'connections-csv-import' -Payload ([ordered]@{
             csvPath    = $csvPath
             isTempFile = $isTempFile
+            mergeExisting = $true
+            sourceLabel = 'linkedin-connections-csv'
         }) -Summary 'Import LinkedIn connections CSV' -ProgressMessage 'Queued connections import'
         Write-ServerLog ("JOB enqueue id={0} type={1}" -f $job.id, $job.type)
         return (New-JsonResult (Get-BackgroundJobAcceptedResult -Job $job) 202)

--- a/server/Server.ps1
+++ b/server/Server.ps1
@@ -1043,6 +1043,7 @@ function Handle-ApiRequest {
 
         $acceptedImport = $null
         $csvContent = [string](Get-ObjectValue -Object $payload -Name 'csvContent' -Default '')
+        $csvFileName = [string](Get-ObjectValue -Object $payload -Name 'csvFileName' -Default '')
         $setupCsvPath = ''
 
         Set-ObjectValue -Object $state -Name 'workspace' -Value $workspace | Out-Null
@@ -1057,6 +1058,8 @@ function Handle-ApiRequest {
                 isTempFile = $true
                 mergeExisting = $true
                 sourceLabel = 'setup-linkedin-connections-csv'
+                sourceFileName = $csvFileName
+                sourceByteLength = [System.Text.Encoding]::UTF8.GetByteCount($csvContent)
             }) -Summary 'Import LinkedIn connections from setup' -ProgressMessage 'Queued LinkedIn connections import'
             Write-ServerLog ("JOB enqueue id={0} type={1} source={2}" -f $job.id, $job.type, 'setup')
             $acceptedImport = Get-BackgroundJobAcceptedResult -Job $job
@@ -2005,16 +2008,22 @@ function Handle-ApiRequest {
         # Support file upload (csvContent) or server-side path (csvPath)
         $csvPath = [string]$payload.csvPath
         $isTempFile = $false
+        $sourceFileName = [string](Get-ObjectValue -Object $payload -Name 'fileName' -Default '')
+        $sourceByteLength = 0
         if ($payload.csvContent -and [string]$payload.csvContent -ne '') {
+            $csvText = [string]$payload.csvContent
+            $sourceByteLength = [System.Text.Encoding]::UTF8.GetByteCount($csvText)
             $dataRoot = if ($env:BD_ENGINE_DATA_ROOT) { [string]$env:BD_ENGINE_DATA_ROOT } else { Join-Path $env:LOCALAPPDATA 'BD Engine\Data' }
             $uploadRoot = Join-Path $dataRoot 'uploads'
             if (-not (Test-Path -LiteralPath $uploadRoot)) {
                 New-Item -ItemType Directory -Path $uploadRoot -Force | Out-Null
             }
             $tempFile = Join-Path $uploadRoot ("connections-" + [System.Guid]::NewGuid().ToString('N') + ".csv")
-            [System.IO.File]::WriteAllText($tempFile, [string]$payload.csvContent, [System.Text.Encoding]::UTF8)
+            [System.IO.File]::WriteAllText($tempFile, $csvText, [System.Text.Encoding]::UTF8)
             $csvPath = $tempFile
             $isTempFile = $true
+        } elseif ($csvPath -and (Test-Path -LiteralPath $csvPath)) {
+            $sourceByteLength = [int64](Get-Item -LiteralPath $csvPath).Length
         }
 
         if (-not $csvPath) {
@@ -2039,6 +2048,8 @@ function Handle-ApiRequest {
             isTempFile = $isTempFile
             mergeExisting = $true
             sourceLabel = 'linkedin-connections-csv'
+            sourceFileName = $sourceFileName
+            sourceByteLength = $sourceByteLength
         }) -Summary 'Import LinkedIn connections CSV' -ProgressMessage 'Queued connections import'
         Write-ServerLog ("JOB enqueue id={0} type={1}" -f $job.id, $job.type)
         return (New-JsonResult (Get-BackgroundJobAcceptedResult -Job $job) 202)

--- a/server/Server.ps1
+++ b/server/Server.ps1
@@ -1045,36 +1045,13 @@ function Handle-ApiRequest {
         $csvContent = [string](Get-ObjectValue -Object $payload -Name 'csvContent' -Default '')
         $setupCsvPath = ''
 
-        if (-not [string]::IsNullOrWhiteSpace($csvContent)) {
-            $setupCsvPath = Join-Path $env:TEMP ("bd-setup-linkedin-" + [System.Guid]::NewGuid().ToString('N') + ".csv")
-            [System.IO.File]::WriteAllText($setupCsvPath, $csvContent, [System.Text.Encoding]::UTF8)
-            try {
-                $validation = Get-BdConnectionsCsvPreview -CsvPath $setupCsvPath -MergeExisting -SourceLabel 'setup-linkedin-connections-csv'
-                $validationStats = $validation.importRun.stats
-                $actionableRows = [int](Get-ObjectValue -Object $validationStats -Name 'imported' -Default 0) + [int](Get-ObjectValue -Object $validationStats -Name 'updated' -Default 0)
-                if ($actionableRows -le 0) {
-                    if (Test-Path -LiteralPath $setupCsvPath) {
-                        Remove-Item -LiteralPath $setupCsvPath -Force -ErrorAction SilentlyContinue
-                    }
-                    return (New-JsonResult ([ordered]@{
-                        error = 'No LinkedIn connection rows were found. Choose the unzipped Connections.csv export from LinkedIn with headers like First Name, Last Name, URL, Email Address, Company, Position, and Connected On.'
-                        stats = $validationStats
-                        preview = @($validation.preview)
-                    }) 400)
-                }
-            } catch {
-                if (Test-Path -LiteralPath $setupCsvPath) {
-                    Remove-Item -LiteralPath $setupCsvPath -Force -ErrorAction SilentlyContinue
-                }
-                return (New-JsonResult ([ordered]@{ error = "LinkedIn Connections.csv could not be read: $($_.Exception.Message)" }) 400)
-            }
-        }
-
         Set-ObjectValue -Object $state -Name 'workspace' -Value $workspace | Out-Null
         Set-ObjectValue -Object $state -Name 'settings' -Value $settings | Out-Null
         Sync-AppStateSegments -State $state -Segments @('Workspace', 'Settings') | Out-Null
 
         if (-not [string]::IsNullOrWhiteSpace($csvContent)) {
+            $setupCsvPath = Join-Path $env:TEMP ("bd-setup-linkedin-" + [System.Guid]::NewGuid().ToString('N') + ".csv")
+            [System.IO.File]::WriteAllText($setupCsvPath, $csvContent, [System.Text.Encoding]::UTF8)
             $job = Enqueue-BackgroundJob -Type 'connections-csv-import' -Payload ([ordered]@{
                 csvPath = $setupCsvPath
                 isTempFile = $true
@@ -2055,27 +2032,6 @@ function Handle-ApiRequest {
                 Remove-Item -LiteralPath $csvPath -Force -ErrorAction SilentlyContinue
             }
             return (New-JsonResult $result.importRun 201)
-        }
-
-        try {
-            $validation = Get-BdConnectionsCsvPreview -CsvPath $csvPath -MergeExisting -SourceLabel 'linkedin-connections-csv'
-            $validationStats = $validation.importRun.stats
-            $actionableRows = [int](Get-ObjectValue -Object $validationStats -Name 'imported' -Default 0) + [int](Get-ObjectValue -Object $validationStats -Name 'updated' -Default 0)
-            if ($actionableRows -le 0) {
-                if ($isTempFile -and (Test-Path -LiteralPath $csvPath)) {
-                    Remove-Item -LiteralPath $csvPath -Force -ErrorAction SilentlyContinue
-                }
-                return (New-JsonResult ([ordered]@{
-                    error = 'No LinkedIn connection rows were found. Choose the unzipped Connections.csv export from LinkedIn with headers like First Name, Last Name, URL, Email Address, Company, Position, and Connected On.'
-                    stats = $validationStats
-                    preview = @($validation.preview)
-                }) 400)
-            }
-        } catch {
-            if ($isTempFile -and (Test-Path -LiteralPath $csvPath)) {
-                Remove-Item -LiteralPath $csvPath -Force -ErrorAction SilentlyContinue
-            }
-            return (New-JsonResult ([ordered]@{ error = "LinkedIn Connections.csv could not be read: $($_.Exception.Message)" }) 400)
         }
 
         $job = Enqueue-BackgroundJob -Type 'connections-csv-import' -Payload ([ordered]@{

--- a/server/Server.ps1
+++ b/server/Server.ps1
@@ -496,6 +496,121 @@ function Convert-ToStringList {
     return @($Value | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | ForEach-Object { $_.Trim() })
 }
 
+function Get-SetupStatus {
+    $state = Get-AppStateView -Segments @('Workspace', 'Settings', 'Companies', 'Contacts', 'ImportRuns')
+    $settings = if ($state.settings) { $state.settings } else { New-DefaultSettings }
+    $workspace = if ($state.workspace) { $state.workspace } else { New-DefaultWorkspace }
+    $setupComplete = Test-Truthy (Get-ObjectValue -Object $settings -Name 'setupComplete' -Default $false)
+    $contactCount = @($state.contacts).Count
+    $companyCount = @($state.companies).Count
+    $importRunCount = @($state.importRuns).Count
+    $hasUserData = ($contactCount -gt 0 -or $companyCount -gt 0 -or $importRunCount -gt 0)
+    $licensingEnabled = (Test-Truthy (Get-ObjectValue -Object $settings -Name 'licensingEnabled' -Default $false)) -or (Test-Truthy $env:BD_ENGINE_LICENSE_ENABLED)
+
+    return [ordered]@{
+        setupComplete = [bool]$setupComplete
+        requiresSetup = (-not [bool]$setupComplete -and -not [bool]$hasUserData)
+        hasUserData = [bool]$hasUserData
+        licensingEnabled = [bool]$licensingEnabled
+        workspace = [ordered]@{
+            id = [string](Get-ObjectValue -Object $workspace -Name 'id' -Default 'workspace-default')
+            name = [string](Get-ObjectValue -Object $workspace -Name 'name' -Default '')
+        }
+        user = Get-ObjectValue -Object $settings -Name 'user' -Default ([ordered]@{})
+        counts = [ordered]@{
+            contacts = $contactCount
+            companies = $companyCount
+            importRuns = $importRunCount
+        }
+    }
+}
+
+function New-SetupOwnerId {
+    param(
+        [string]$DisplayName,
+        [string]$Email,
+        [hashtable]$UsedIds
+    )
+
+    $seed = if (-not [string]::IsNullOrWhiteSpace($Email)) {
+        ($Email -split '@', 2)[0]
+    } else {
+        $DisplayName
+    }
+    $base = (Normalize-TextKey $seed) -replace '\s+', '-'
+    if ([string]::IsNullOrWhiteSpace($base)) {
+        $base = 'owner'
+    }
+
+    $candidate = $base
+    $suffix = 2
+    while ($UsedIds.ContainsKey($candidate)) {
+        $candidate = '{0}-{1}' -f $base, $suffix
+        $suffix++
+    }
+    $UsedIds[$candidate] = $true
+    return $candidate
+}
+
+function Convert-ToSetupOwnerRoster {
+    param(
+        $Owners,
+        [string]$UserName = '',
+        [string]$UserEmail = ''
+    )
+
+    $rows = New-Object System.Collections.ArrayList
+    if ($Owners -is [string]) {
+        foreach ($line in ($Owners -split "`r?`n")) {
+            $text = $line.Trim()
+            if (-not $text) { continue }
+            $email = ''
+            if ($text -match '<([^>]+)>') {
+                $email = $matches[1].Trim()
+                $text = ($text -replace '<[^>]+>', '').Trim()
+            } elseif ($text -match ',') {
+                $parts = $text -split ',', 2
+                $text = $parts[0].Trim()
+                $email = $parts[1].Trim()
+            }
+            [void]$rows.Add([ordered]@{ displayName = $text; email = $email })
+        }
+    } elseif ($Owners) {
+        foreach ($owner in @($Owners)) {
+            $displayName = [string](Get-ObjectValue -Object $owner -Name 'displayName' -Default (Get-ObjectValue -Object $owner -Name 'name' -Default ''))
+            $email = [string](Get-ObjectValue -Object $owner -Name 'email' -Default '')
+            if (-not [string]::IsNullOrWhiteSpace($displayName) -or -not [string]::IsNullOrWhiteSpace($email)) {
+                [void]$rows.Add([ordered]@{ displayName = $displayName.Trim(); email = $email.Trim() })
+            }
+        }
+    }
+
+    if ($rows.Count -eq 0 -and -not [string]::IsNullOrWhiteSpace($UserName)) {
+        [void]$rows.Add([ordered]@{ displayName = $UserName.Trim(); email = $UserEmail.Trim() })
+    }
+
+    $usedIds = @{}
+    $ownersOut = New-Object System.Collections.ArrayList
+    foreach ($row in @($rows)) {
+        $displayName = [string](Get-ObjectValue -Object $row -Name 'displayName' -Default '')
+        $email = [string](Get-ObjectValue -Object $row -Name 'email' -Default '')
+        if ([string]::IsNullOrWhiteSpace($displayName) -and -not [string]::IsNullOrWhiteSpace($email)) {
+            $displayName = $email
+        }
+        if ([string]::IsNullOrWhiteSpace($displayName)) {
+            continue
+        }
+
+        [void]$ownersOut.Add([ordered]@{
+            ownerId = New-SetupOwnerId -DisplayName $displayName -Email $email -UsedIds $usedIds
+            displayName = $displayName
+            email = $email
+        })
+    }
+
+    return @($ownersOut)
+}
+
 function Convert-ToAccountImportRow {
     param(
         [Parameter(Mandatory = $true)]
@@ -876,6 +991,86 @@ function Handle-ApiRequest {
     }
     if ($path -eq '/api/runtime/status' -and $method -eq 'GET') {
         return (New-JsonResult (Get-BackgroundRuntimeStatus -ServerStartedAt $script:ServerStartedAt -ServerWarmedAt $script:ServerWarmedAt))
+    }
+    if ($path -eq '/api/setup/status' -and $method -eq 'GET') {
+        return (New-JsonResult (Get-SetupStatus))
+    }
+    if ($path -eq '/api/setup/complete' -and $method -eq 'POST') {
+        $payload = Read-JsonBody -Request $Request
+        $workspaceName = ([string](Get-ObjectValue -Object $payload -Name 'workspaceName' -Default '')).Trim()
+        $userName = ([string](Get-ObjectValue -Object $payload -Name 'userName' -Default '')).Trim()
+        $userEmail = ([string](Get-ObjectValue -Object $payload -Name 'userEmail' -Default '')).Trim()
+
+        if ([string]::IsNullOrWhiteSpace($workspaceName)) {
+            return (New-JsonResult ([ordered]@{ error = 'Workspace or company name is required.' }) 400)
+        }
+        if ([string]::IsNullOrWhiteSpace($userName)) {
+            return (New-JsonResult ([ordered]@{ error = 'Your name is required.' }) 400)
+        }
+        if ([string]::IsNullOrWhiteSpace($userEmail)) {
+            return (New-JsonResult ([ordered]@{ error = 'Your email is required.' }) 400)
+        }
+
+        $state = Get-AppState
+        foreach ($collectionName in 'companies', 'contacts', 'jobs', 'boardConfigs', 'activities', 'importRuns') {
+            if ($null -eq $state[$collectionName]) {
+                $state[$collectionName] = @()
+            }
+        }
+
+        $workspace = if ($state.workspace) { $state.workspace } else { New-DefaultWorkspace }
+        Set-ObjectValue -Object $workspace -Name 'name' -Value $workspaceName | Out-Null
+        Set-ObjectValue -Object $workspace -Name 'companyName' -Value $workspaceName | Out-Null
+        Set-ObjectValue -Object $workspace -Name 'updatedAt' -Value (Get-Date).ToString('o') | Out-Null
+
+        $settings = if ($state.settings) { $state.settings } else { New-DefaultSettings }
+        $licensingEnabled = (Test-Truthy (Get-ObjectValue -Object $settings -Name 'licensingEnabled' -Default $false)) -or (Test-Truthy $env:BD_ENGINE_LICENSE_ENABLED)
+        Set-ObjectValue -Object $settings -Name 'setupComplete' -Value $true | Out-Null
+        Set-ObjectValue -Object $settings -Name 'setupCompletedAt' -Value (Get-Date).ToString('o') | Out-Null
+        Set-ObjectValue -Object $settings -Name 'updatedAt' -Value (Get-Date).ToString('o') | Out-Null
+        Set-ObjectValue -Object $settings -Name 'user' -Value ([ordered]@{
+            name = $userName
+            email = $userEmail
+        }) | Out-Null
+        Set-ObjectValue -Object $settings -Name 'ownerRoster' -Value (Convert-ToSetupOwnerRoster -Owners (Get-ObjectValue -Object $payload -Name 'owners' -Default @()) -UserName $userName -UserEmail $userEmail) | Out-Null
+        if ($licensingEnabled -and (Get-ObjectValue -Object $payload -Name 'licenseKey' -Default '')) {
+            Set-ObjectValue -Object $settings -Name 'license' -Value ([ordered]@{
+                status = 'provided'
+                key = [string](Get-ObjectValue -Object $payload -Name 'licenseKey' -Default '')
+                updatedAt = (Get-Date).ToString('o')
+            }) | Out-Null
+        }
+
+        $importResult = $null
+        $csvContent = [string](Get-ObjectValue -Object $payload -Name 'csvContent' -Default '')
+        $tempFile = ''
+        try {
+            if (-not [string]::IsNullOrWhiteSpace($csvContent)) {
+                $tempFile = Join-Path $env:TEMP ("bd-setup-linkedin-" + [System.Guid]::NewGuid().ToString('N') + ".csv")
+                [System.IO.File]::WriteAllText($tempFile, $csvContent, [System.Text.Encoding]::UTF8)
+                $importResult = Import-BdConnectionsCsv -CsvPath $tempFile -SourceLabel 'setup-linkedin-connections-csv' -MergeExisting -SkipPersistence
+                $state = $importResult.state
+            }
+
+            Set-ObjectValue -Object $state -Name 'workspace' -Value $workspace | Out-Null
+            Set-ObjectValue -Object $state -Name 'settings' -Value $settings | Out-Null
+            $segments = @('Workspace', 'Settings')
+            if ($importResult) {
+                $segments += @('Contacts', 'Companies', 'BoardConfigs', 'ImportRuns')
+            }
+            Sync-AppStateSegments -State $state -Segments $segments | Out-Null
+        } finally {
+            if ($tempFile -and (Test-Path -LiteralPath $tempFile)) {
+                Remove-Item -LiteralPath $tempFile -Force -ErrorAction SilentlyContinue
+            }
+        }
+
+        return (New-JsonResult ([ordered]@{
+            status = Get-SetupStatus
+            importRun = if ($importResult) { $importResult.importRun } else { $null }
+            stats = if ($importResult) { $importResult.importRun.stats } else { [ordered]@{ contacts = 0; companies = 0; imported = 0; updated = 0; skipped = 0; failed = 0 } }
+            preview = if ($importResult) { @($importResult.preview) } else { @() }
+        }) 200)
     }
     if ($path -eq '/api/background-jobs' -and $method -eq 'GET') {
         return (New-JsonResult (Find-AppBackgroundJobs -Query $query))
@@ -1771,6 +1966,39 @@ function Handle-ApiRequest {
         }) -Summary 'Reimport workbook seed data' -ProgressMessage 'Queued workbook import'
         Write-ServerLog ("JOB enqueue id={0} type={1}" -f $job.id, $job.type)
         return (New-JsonResult (Get-BackgroundJobAcceptedResult -Job $job) 202)
+    }
+    if ($path -eq '/api/import/connections-csv/preview' -and $method -eq 'POST') {
+        $payload = Read-JsonBody -Request $Request
+        $csvPath = [string](Get-ObjectValue -Object $payload -Name 'csvPath' -Default '')
+        $isTempFile = $false
+        $csvContent = [string](Get-ObjectValue -Object $payload -Name 'csvContent' -Default '')
+        if (-not [string]::IsNullOrWhiteSpace($csvContent)) {
+            $tempFile = Join-Path $env:TEMP ("bd-csv-preview-" + [System.Guid]::NewGuid().ToString('N') + ".csv")
+            [System.IO.File]::WriteAllText($tempFile, $csvContent, [System.Text.Encoding]::UTF8)
+            $csvPath = $tempFile
+            $isTempFile = $true
+        }
+
+        if ([string]::IsNullOrWhiteSpace($csvPath)) {
+            return (New-JsonResult ([ordered]@{ error = 'csvPath or csvContent is required' }) 400)
+        }
+
+        try {
+            $result = Import-BdConnectionsCsv `
+                -CsvPath $csvPath `
+                -DryRun `
+                -MergeExisting `
+                -UseEmptyState:(Test-Truthy (Get-ObjectValue -Object $payload -Name 'useEmptyState' -Default $false))
+            return (New-JsonResult ([ordered]@{
+                importRun = $result.importRun
+                stats = $result.importRun.stats
+                preview = @($result.preview)
+            }) 200)
+        } finally {
+            if ($isTempFile -and (Test-Path -LiteralPath $csvPath)) {
+                Remove-Item -LiteralPath $csvPath -Force -ErrorAction SilentlyContinue
+            }
+        }
     }
     if ($path -eq '/api/import/connections-csv' -and $method -eq 'POST') {
         $payload = Read-JsonBody -Request $Request

--- a/server/Server.ps1
+++ b/server/Server.ps1
@@ -2006,7 +2006,12 @@ function Handle-ApiRequest {
         $csvPath = [string]$payload.csvPath
         $isTempFile = $false
         if ($payload.csvContent -and [string]$payload.csvContent -ne '') {
-            $tempFile = Join-Path $env:TEMP ("bd-csv-" + [System.Guid]::NewGuid().ToString('N') + ".csv")
+            $dataRoot = if ($env:BD_ENGINE_DATA_ROOT) { [string]$env:BD_ENGINE_DATA_ROOT } else { Join-Path $env:LOCALAPPDATA 'BD Engine\Data' }
+            $uploadRoot = Join-Path $dataRoot 'uploads'
+            if (-not (Test-Path -LiteralPath $uploadRoot)) {
+                New-Item -ItemType Directory -Path $uploadRoot -Force | Out-Null
+            }
+            $tempFile = Join-Path $uploadRoot ("connections-" + [System.Guid]::NewGuid().ToString('N') + ".csv")
             [System.IO.File]::WriteAllText($tempFile, [string]$payload.csvContent, [System.Text.Encoding]::UTF8)
             $csvPath = $tempFile
             $isTempFile = $true
@@ -2014,6 +2019,9 @@ function Handle-ApiRequest {
 
         if (-not $csvPath) {
             return (New-JsonResult ([ordered]@{ error = 'csvPath or csvContent is required' }) 400)
+        }
+        if (-not (Test-Path -LiteralPath $csvPath)) {
+            return (New-JsonResult ([ordered]@{ error = "CSV file not found: $csvPath" }) 400)
         }
         if (Test-Truthy $payload.dryRun) {
             $result = Import-BdConnectionsCsv `


### PR DESCRIPTION
## Summary

Implements Phase 2 of GitHub issue #6 on top of the Phase 1 Windows packaging branch, with the v0 frontend restored into the packaged app. This update also adds the first practical contact outreach workflow: pick a contact, generate tailored email + LinkedIn copy from the account's hiring signals/open roles, send through the user's own tools, then log the touch and schedule follow-up.

### First-run logic
- Adds `/api/setup/status` to detect a fresh local data store: setup is required when setup is not complete and no user contacts/accounts/import history exist.
- Adds `/api/setup/complete` to persist workspace/company name, user name/email, optional owner roster, and license key only when licensing is enabled.
- The frontend checks setup status during startup, routes fresh installs to `#/setup`, and skips the wizard once setup is complete.
- Setup completion now queues large LinkedIn CSV imports as a background job so the wizard shows progress instead of appearing stuck.

### LinkedIn import mapping
- Accepts LinkedIn `Connections.csv` fields including `First Name`, `Last Name`, `URL`, `Email Address`, `Company`, `Position`, and `Connected On`, plus common aliases.
- Normalizes names, company names, titles, emails, LinkedIn URLs, and connected dates.
- Handles missing optional fields without crashing and previews records before final import.

### Dedupe strategy
- Dedupe order is LinkedIn URL, then email, then fallback `name + company`.
- Repeated imports update existing contacts and preserve outreach status, notes, created date, and account linkage where available.
- Duplicate rows inside the same CSV are skipped and reported in the preview/import summary.

### Contact outreach workflow
- Contacts now have an `Outreach` action that opens the related account, preselects that person, and opens the outreach composer.
- The existing smart outreach endpoint is reused to generate tailored email, LinkedIn DM, follow-up, and call-opener copy from account/company context and open-role signals.
- Generated email can be copied, opened with the system mail client, or drafted in Gmail with the contact email prefilled when available.
- Generated LinkedIn copy is copied to the clipboard and opens the contact's LinkedIn URL when available.
- `Log sent + follow-up` creates an activity note, marks the account/contact as contacted, stores the draft/source metadata, and sets a one-week follow-up via account `nextActionAt` plus the existing local sequence panel.
- Direct automated sending through LinkedIn or the user's mailbox is intentionally not implemented in this phase; the user remains in control of the final send from their own accounts.

### New endpoints/functions added
- `GET /api/setup/status`
- `POST /api/setup/complete`
- `POST /api/import/connections-csv/preview`
- Setup import reuses the existing `connections-csv-import` background job type and `/api/background-jobs/:id` polling.
- Contact outreach reuses `POST /api/accounts/:id/generate-outreach`, `POST /api/activity`, `PATCH /api/accounts/:id`, and `PATCH /api/contacts/:id`.
- Shared LinkedIn CSV import planning/normalization helpers in `BdEngine.Import.psm1`
- Strict-mode/key-existence hardening in state/domain/SQLite helpers used by activity logging and persistence.
- Configurable owner roster support from settings, with legacy fallback preserved for existing workspaces.

### Files added/changed
- Setup wizard, contact outreach actions, smart outreach composer wiring, and log/follow-up UX in `app/app.js`
- Wizard/progress styling and v0 frontend polish in `app/styles.css`
- v0 shell/cache updates in `app/index.html` and `app/sw.js`
- Setup/import API work in `server/Server.ps1`
- Background setup import support in `server/Modules/BdEngine.BackgroundJobs.psm1`
- LinkedIn preview/import/dedupe work in `server/Modules/BdEngine.Import.psm1`
- Activity/persistence hardening in `server/Modules/BdEngine.Domain.psm1`, `server/Modules/BdEngine.State.psm1`, and `server/Modules/BdEngine.SqliteStore.psm1`
- Docs updates in `DIST_README.md` and `PACKAGING.md`
- Header-only sample template at `packaging/empty-data/sample-linkedin-connections.csv`

### How to build the installer
- Run `powershell -NoProfile -ExecutionPolicy Bypass -File scripts/package-windows.ps1`
- Output: `dist/BD-Engine-Setup.exe`

### Testing performed
- `node --check app/app.js`
- `node --check app/local-api.js`
- `node --check app/sw.js`
- PowerShell parser checks for changed `.ps1`/`.psm1` files
- `git diff --check`
- `scripts/package-windows.ps1`
- Live isolated-data smoke test against `server/Server.ps1`:
  - fresh data root requires setup
  - v0 frontend asset version is served from `index.html`
  - setup completion returns quickly while queuing the LinkedIn import background job
  - background import completes with imported contacts/accounts
  - accounts and contacts endpoints return imported records with normal pagination
  - account smart outreach generation returns an email/LinkedIn draft for the selected contact
  - outreach activity logging succeeds
  - account/contact patching marks the outreach as contacted and sets a one-week follow-up
- Package hygiene scan:
  - rebuilt `dist/BD-Engine-Setup.exe`
  - package stage has no real `data` folder
  - LinkedIn sample CSV is header-only
  - no vendor license-generation-looking files are included in the customer package stage
- Patched the locally installed app under `%LOCALAPPDATA%\Programs\BD Engine` and restarted it against the existing user data root.

### Manual review needed
- Installer compile/install validation on a clean Windows VM/profile.
- Browser QA of the restored v0 frontend, first-run wizard, and contact outreach workflow at desktop and mobile widths.
- Confirm current LinkedIn export wording against the latest LinkedIn UI before customer-facing release copy is finalized.
- Confirm the user's preferred email client flow beyond `mailto:` and Gmail draft links.

### Deferred follow-up / Phase 3
- Native launcher executable/signing instead of PowerShell launcher script.
- Direct email provider integration with OAuth and clear send permissions.
- Direct LinkedIn sending is deferred unless/until there is an approved compliant integration path; current behavior opens/copies for manual send.
- Richer import progress percentages for very large LinkedIn exports.
- Optional post-install launch/repair/uninstall UX beyond the current Inno Setup defaults.