### PR TITLE
Quiet expected startup readiness probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable customer-facing changes are recorded here. The project is currently 
 - Added read-only live Stripe catalog and webhook verification, and accepted
   both supported successful-invoice event variants for payment recovery.
 - Labeled paid plan prices as USD in public and in-app billing surfaces.
+- Kept expected pre-initialization readiness probes from creating false error alerts.
 - Restricted browser resource loading with a full Content Security Policy, stopped trusting Host headers for customer URLs, and reduced CI workflow tokens to read-only permissions.
 - Replaced the broad inline-script CSP exception with a per-response cryptographic nonce.
 - Hardened signup, login, reset, demo, analytics, and client-error rate limits against spoofed forwarded IP headers.

--- a/saas/src/readiness.js
+++ b/saas/src/readiness.js
@@ -29,3 +29,7 @@ export function getReadinessDecision({
   }
   return { ready: true };
 }
+
+export function shouldLogReadinessFailure(decision = {}) {
+  return decision.ready === false && decision.reason !== 'startup incomplete';
+}

--- a/saas/src/server.js
+++ b/saas/src/server.js
@@ -10,7 +10,7 @@ import { createUser, authenticateUser, setUserPassword, markUserEmailVerified, f
 import { getPlan, getPlanByStripePriceId, getTrialDaysRemaining, getUsageSummary, getEntitlementDecision, PLANS, handleWebhookEvent, createCheckoutSession, createBillingPortalSession, cancelSubscriptionForAccountClosure, createReferralCredit, isStripeConfigured, getStripeConfigStatus, isTrialExpired, createBillingGraceDeadline, getBillingAccessStatus } from './billing.js';
 import { initDb, closeDb, isDbEnabled, isDbReady, dbCheckRelationalContentParity, dbCheckRelationalCountParity, dbLoadRelationalPrimaryTenantIds, dbPruneExpiredOperationalData, dbRecordAnalyticsVisit, dbRecordProductEvent, dbRecordAuditLog, dbGetAnalyticsSummary, dbGetImportUsageCount, dbClaimStripeWebhook, dbCompleteStripeWebhook, dbFailStripeWebhook, dbConsumeRateLimit, dbRecordAccountClosure, dbCloseUserAccount, dbSavePasswordResetToken, dbFindPasswordResetToken, dbMarkPasswordResetTokenUsed, dbSaveEmailVerificationToken, dbFindEmailVerificationToken, dbMarkEmailVerificationTokenUsed, dbCreateSupportTicket, dbListSupportTickets, dbGetSupportTicket, dbAddSupportTicketMessage, dbUpdateSupportTicket } from './db.js';
 import { isEmailConfigured, sendPasswordResetEmail, sendEmailVerificationEmail, sendSupportOperatorEmail, sendSupportCustomerReplyEmail } from './email.js';
-import { getReadinessDecision } from './readiness.js';
+import { getReadinessDecision, shouldLogReadinessFailure } from './readiness.js';
 import { buildMutationAuditEntry } from './request-audit.js';
 import { validateSupportTicketInput, validateSupportReplyInput, validateSupportAdminUpdate, publicSupportTicket, SUPPORT_STATUSES } from './support.js';
 import { canDeleteWorkspaceData, canManageBilling, canMutateWorkspace } from './authorization.js';
@@ -789,7 +789,7 @@ async function route(req, res) {
   // The detailed reason is logged, not published (CG-016).
   if (pathname === '/readyz') {
     const decision = getCurrentReadiness();
-    if (!decision.ready) console.error(`Readiness check failed: ${decision.reason}`);
+    if (shouldLogReadinessFailure(decision)) console.error(`Readiness check failed: ${decision.reason}`);
     return sendJson(res, decision.ready ? 200 : 503, { ok: decision.ready });
   }
 

--- a/saas/test/readiness.test.js
+++ b/saas/test/readiness.test.js
@@ -4,7 +4,7 @@
  */
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { getReadinessDecision } from '../src/readiness.js';
+import { getReadinessDecision, shouldLogReadinessFailure } from '../src/readiness.js';
 
 test('production with connected database is ready', () => {
   const decision = getReadinessDecision({ isProduction: true, startupComplete: true, dbEnabled: true, dbReady: true });
@@ -40,4 +40,11 @@ test('incomplete startup reports not ready without an error', () => {
 test('development in-memory mode is intentionally ready', () => {
   const decision = getReadinessDecision({ isProduction: false, startupComplete: true, dbEnabled: false, dbReady: false });
   assert.deepEqual(decision, { ready: true });
+});
+
+test('normal startup transition stays quiet while real readiness failures are logged', () => {
+  assert.equal(shouldLogReadinessFailure({ ready: false, reason: 'startup incomplete' }), false);
+  assert.equal(shouldLogReadinessFailure({ ready: false, reason: 'database is not connected' }), true);
+  assert.equal(shouldLogReadinessFailure({ ready: false, reason: 'startup failed: boom' }), true);
+  assert.equal(shouldLogReadinessFailure({ ready: true }), false);
 });


### PR DESCRIPTION
## Summary

Prevents normal Railway startup health checks from creating false production error alerts.

- `/readyz` still returns 503 until initialization finishes
- expected `startup incomplete` transitions no longer log at error level
- database disconnects and genuine startup failures continue to log as errors

## Evidence

The healthy billing deployment emitted `Readiness check failed: startup incomplete` during its first Railway probe, then initialized PostgreSQL and served normally. The new decision test covers expected startup, database failure, explicit startup failure, and healthy readiness.