### PR TITLE
Run production schedules from the default branch

### DIFF
--- a/.github/workflows/ats-live-canary.yml
+++ b/.github/workflows/ats-live-canary.yml
@@ -1,0 +1,15 @@
+name: ATS live canary scheduler
+
+on:
+  schedule:
+    - cron: '17 13 * * 1,4'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  provider-compatibility:
+    uses: dgrant22345/bd-engine/.github/workflows/ats-live-canary.yml@deploy/perf-restore
+    permissions:
+      contents: read

--- a/.github/workflows/production-probe.yml
+++ b/.github/workflows/production-probe.yml
@@ -1,0 +1,15 @@
+name: Production read-only probe scheduler
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    uses: dgrant22345/bd-engine/.github/workflows/production-probe.yml@deploy/perf-restore
+    permissions:
+      contents: read


### PR DESCRIPTION
## Summary
- register the production read-only probe on GitHub's default branch
- register the ATS live canary on GitHub's default branch
- delegate both jobs to the reviewed reusable workflows on `deploy/perf-restore`

## Why
GitHub only registers `schedule` events from the default branch. These wrappers keep `main` minimal while ensuring scheduled checks execute the same code Railway serves.

## Safety
Both delegated workflows are read-only, use `contents: read`, and accept no secrets from this wrapper.