### PR TITLE
Run scheduled checks against the deployment branch

### DIFF
--- a/.github/workflows/ats-live-canary.yml
+++ b/.github/workflows/ats-live-canary.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: deploy/perf-restore
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4

--- a/.github/workflows/production-probe.yml
+++ b/.github/workflows/production-probe.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: deploy/perf-restore
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable customer-facing changes are recorded here. The project is currently 
 
 - Activated the production and ATS scheduled checks through default-branch
   schedulers that delegate to the Railway deployment branch.
+- Pinned delegated scheduler checkouts to the Railway deployment branch so
+  dependency caches and probes run against the intended release.
 
 - Preserved signup workspace and profile details through first-run setup.
 - Corrected sample-workspace readiness after data is loaded.


### PR DESCRIPTION
## Summary
- explicitly check out `deploy/perf-restore` inside both reusable workflows
- keep setup-node caching and all probes aligned with the Railway release

## Evidence
The first default-branch dispatches reached the reusable jobs but failed at `actions/setup-node` because `actions/checkout` otherwise selected the caller's `main` ref, where the SaaS lockfile is absent. This pins the intended ref before dependency setup.