### PR TITLE
Harden customer billing boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable customer-facing changes are recorded here. The project is currently 
   schedulers that delegate to the Railway deployment branch.
 - Pinned delegated scheduler checkouts to the Railway deployment branch so
   dependency caches and probes run against the intended release.
+- Required both paid Stripe prices before billing reports ready, converted
+  provider failures into actionable customer-safe responses, and added direct
+  coverage for checkout payloads, signed webhooks, referral credits, portal
+  sessions, and subscription cancellation.
 
 - Preserved signup workspace and profile details through first-run setup.
 - Corrected sample-workspace readiness after data is loaded.

--- a/docs/commercial-launch-checklist.md
+++ b/docs/commercial-launch-checklist.md
@@ -77,12 +77,16 @@ and durable evidence link or identifier. Never paste secrets or customer rows.
   failed-payment, and successful-payment events. Evidence: 2026-07-19 read-only
   production catalog verification passed after the event allowlist correction.
 - [ ] Stripe live checkout succeeds for Job Seeker and Sales Professional.
-- [ ] Signed webhook activation, duplicate delivery, failed payment, grace period,
-  recovery, cancellation, portal access, and invoice access were tested.
+- [x] Signed webhook acceptance, tamper rejection, duplicate delivery, checkout
+  payloads, referral credits, portal sessions, and idempotent account-closure
+  cancellation pass automated contract tests. Evidence: required billing tests.
+- [ ] Live webhook delivery, failed payment, grace period, recovery, cancellation,
+  portal access, and invoice access were tested against Stripe.
 - [x] Plan entitlements and limits match the public pricing page. Evidence:
   `public prices and limits match enforced plan entitlements` required unit test.
-- [ ] Account closure cancels the affected subscription and removes access/data;
-  shared-workspace ownership blockers and retry recovery were tested.
+- [x] Account closure cancellation, shared-workspace ownership blockers, data
+  removal, and failed-dependency recovery pass automated tests and local smoke.
+- [ ] Account closure was exercised with a live test subscription.
 - [ ] Support ownership, response target, escalation path, refund policy, and
   incident communications are documented and staffed.
 
@@ -98,12 +102,11 @@ Evidence for this section: `________________`
   ATS discovery, one job refresh, support, billing, export, and logout passed.
 - [ ] Authenticated status reports database/parity health, queue age below the
   threshold, 5xx rate below 1%, and ingestion success at or above 95%.
-- [ ] The scheduled production probe is green and external paging is active.
+- [x] The default-branch scheduled production probe is registered and green.
   The probe now covers availability, readiness, anonymous authorization,
   pricing, CSP nonces, security headers, secure demo sessions, app mounting,
-  and read-only demo boundaries. The default branch scheduler delegates to the
-  reusable workflow on `deploy/perf-restore`; external paging remains
-  operator-owned.
+  and read-only demo boundaries. Evidence: GitHub Actions run 2 on 2026-07-19.
+- [ ] External paging is active and reaches an accountable operator.
 - [ ] Logs and alerts were watched through the agreed observation window.
 
 Observation owner/window/evidence: `________________`

--- a/docs/commercial-launch-readiness-2026-07-18.md
+++ b/docs/commercial-launch-readiness-2026-07-18.md
@@ -35,7 +35,7 @@ PowerShell/SQLite edition remains supported separately.
 ## Verified baseline
 
 - SaaS syntax checks: pass.
-- SaaS unit/contract tests: 184/184 pass.
+- SaaS unit/contract tests: 198/198 pass.
 - Chromium customer journeys and accessibility checks: 22/22 pass.
 - Compact compatibility journey: Chromium, Firefox, and WebKit pass.
 - Renderer checks/tests: 4/4 pass.
@@ -88,8 +88,10 @@ PowerShell/SQLite edition remains supported separately.
 2. Both live Stripe prices and products are active with the advertised monthly
    USD amounts. The canonical webhook is enabled for all six required checkout,
    subscription, failed-payment, and recovery events, and the read-only catalog
-   verifier passes. Signed test delivery and live checkout/failure/refund
-   exercises are still required before payment operations are launch-approved.
+   verifier passes. Local boundary tests now prove signed payload acceptance,
+   tamper rejection, checkout and portal contracts, referral credits, and
+   idempotent subscription cancellation. Live checkout/failure/refund exercises
+   are still required before payment operations are launch-approved.
 3. The main legacy workspace has 12,235 mechanically linkable board records and
    12,317 unclassified legacy companies. Discovery is diluted across an entire
    network history. A dry-run board-link repair and owner-confirmed target

--- a/saas/scripts/smoke.mjs
+++ b/saas/scripts/smoke.mjs
@@ -141,6 +141,19 @@ await mutationCheck('authenticated status includes operator detail', async () =>
   assert(Object.prototype.hasOwnProperty.call(body.checks || {}, 'relationalContentHealthy'), '/api/status omitted relational content readiness');
 });
 
+await mutationCheck('unavailable checkout fails safely without provider details', async () => {
+  const response = await fetch(`${baseUrl}/api/billing/checkout`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Cookie: cookie },
+    body: JSON.stringify({ planId: 'sales' }),
+  });
+  assert(response.status === 503, `unavailable checkout expected 503, got ${response.status}`);
+  const body = await response.json();
+  assert(body.code === 'billing_unavailable', 'checkout did not return billing_unavailable');
+  assert(Boolean(body.requestId), 'checkout failure did not include a support request ID');
+  assert(!/STRIPE_|secret|price_/i.test(body.error || ''), 'checkout exposed provider configuration details');
+});
+
 await mutationCheck('manual ATS URL creates an import-ready board config', async () => {
   const response = await fetch(`${baseUrl}/api/configs`, {
     method: 'POST',

--- a/saas/src/billing.js
+++ b/saas/src/billing.js
@@ -19,6 +19,16 @@ const stripeSecretKey = normalizeStripeSecretKey(process.env.STRIPE_SECRET_KEY);
 const stripe = stripeSecretKey ? new Stripe(stripeSecretKey, { apiVersion: '2023-10-16' }) : null;
 const DEFAULT_BILLING_GRACE_DAYS = 7;
 
+export class BillingError extends Error {
+  constructor(message, { code = 'billing_error', status = 400, report = false } = {}) {
+    super(message);
+    this.name = 'BillingError';
+    this.code = code;
+    this.status = status;
+    this.report = report;
+  }
+}
+
 export function getBillingGraceDays() {
   const configured = Number(process.env.BD_BILLING_GRACE_DAYS);
   return Number.isFinite(configured) && configured >= 1 && configured <= 30
@@ -61,36 +71,50 @@ export function isStripeConfigured() {
   return Boolean(stripe);
 }
 
-export function getStripeConfigStatus() {
-  const secretKey = stripeSecretKey;
+export function assessStripeConfig({
+  secretKey = '',
+  webhookSecret = '',
+  priceIds = {},
+  allowTestCheckout = false,
+  clientConfigured = Boolean(secretKey),
+} = {}) {
   const mode = getStripeKeyMode(secretKey);
-  const allowTestCheckout = process.env.BD_ALLOW_TEST_CHECKOUT === 'true';
-  const priceIds = {
-    jobseeker: process.env.STRIPE_PRICE_JOBSEEKER || '',
-    sales: process.env.STRIPE_PRICE_SALES || '',
-  };
-  const ready = Boolean(stripe && process.env.STRIPE_WEBHOOK_SECRET && (priceIds.jobseeker || priceIds.sales));
+  const allPricesConfigured = Boolean(priceIds.jobseeker && priceIds.sales);
+  const ready = Boolean(clientConfigured && webhookSecret && allPricesConfigured);
   const liveMode = mode === 'live';
   const missing = [];
-  if (!process.env.STRIPE_SECRET_KEY) missing.push('STRIPE_SECRET_KEY');
-  if (!process.env.STRIPE_WEBHOOK_SECRET) missing.push('STRIPE_WEBHOOK_SECRET');
-  if (!process.env.STRIPE_PRICE_JOBSEEKER) missing.push('STRIPE_PRICE_JOBSEEKER');
-  if (!process.env.STRIPE_PRICE_SALES) missing.push('STRIPE_PRICE_SALES');
+  if (!secretKey) missing.push('STRIPE_SECRET_KEY');
+  if (!webhookSecret) missing.push('STRIPE_WEBHOOK_SECRET');
+  if (!priceIds.jobseeker) missing.push('STRIPE_PRICE_JOBSEEKER');
+  if (!priceIds.sales) missing.push('STRIPE_PRICE_SALES');
   return {
-    configured: Boolean(stripe),
+    configured: Boolean(clientConfigured),
     ready,
     liveMode,
     allowTestCheckout,
     checkoutReady: Boolean(ready && (liveMode || allowTestCheckout)),
     commercialReady: Boolean(ready && liveMode),
     mode,
-    allPricesConfigured: Boolean(priceIds.jobseeker && priceIds.sales),
+    allPricesConfigured,
     missing,
     prices: {
       jobseeker: Boolean(priceIds.jobseeker),
       sales: Boolean(priceIds.sales),
     },
   };
+}
+
+export function getStripeConfigStatus() {
+  return assessStripeConfig({
+    secretKey: stripeSecretKey,
+    webhookSecret: process.env.STRIPE_WEBHOOK_SECRET || '',
+    priceIds: {
+      jobseeker: process.env.STRIPE_PRICE_JOBSEEKER || '',
+      sales: process.env.STRIPE_PRICE_SALES || '',
+    },
+    allowTestCheckout: process.env.BD_ALLOW_TEST_CHECKOUT === 'true',
+    clientConfigured: Boolean(stripe),
+  });
 }
 
 export const PLANS = {
@@ -246,23 +270,25 @@ export function getUsageSummary(tenantId, planId, actualUsage = {}) {
 
 // ── Stripe Checkout ─────────────────────────────────────────────────────────
 
-export async function createCheckoutSession(tenantId, userEmail, planId, successUrl, cancelUrl, metadata = {}, options = {}) {
-  if (!stripe) throw new Error('Stripe is not configured. Add STRIPE_SECRET_KEY environment variable.');
-  const status = getStripeConfigStatus();
-  if (!status.checkoutReady) {
-    throw new Error('Live Stripe checkout is not enabled yet. Set live Stripe keys before taking public paid upgrades.');
+export function buildStripeCheckoutParams({ tenantId, userEmail, plan, successUrl, cancelUrl, metadata = {}, customerId = '' }) {
+  if (!plan?.stripePriceEnv) {
+    throw new BillingError('Choose the Job Seeker or Sales Professional plan.', {
+      code: 'invalid_billing_plan',
+      status: 400,
+    });
   }
-  
-  const plan = getPlan(planId);
-  if (!plan || !plan.stripePriceId) throw new Error('Invalid plan selected.');
   if (!plan.stripePriceId || plan.stripePriceId.startsWith('price_placeholder')) {
-    throw new Error(`Stripe price ID is not configured for ${plan.displayName}. Set ${plan.stripePriceEnv || 'the plan price environment variable'}.`);
+    throw new BillingError('Checkout is temporarily unavailable. Please contact support.', {
+      code: 'billing_unavailable',
+      status: 503,
+      report: true,
+    });
   }
 
   const checkoutMetadata = {
+    ...Object.fromEntries(Object.entries(metadata || {}).filter(([, value]) => value !== undefined && value !== null && value !== '')),
     tenantId,
     planId: plan.id,
-    ...Object.fromEntries(Object.entries(metadata || {}).filter(([, value]) => value !== undefined && value !== null && value !== '')),
   };
 
   const checkoutParams = {
@@ -278,22 +304,47 @@ export async function createCheckoutSession(tenantId, userEmail, planId, success
     cancel_url: cancelUrl,
   };
 
-  if (options.customerId) {
-    checkoutParams.customer = options.customerId;
+  if (customerId) {
+    checkoutParams.customer = customerId;
   } else {
     checkoutParams.customer_email = userEmail;
   }
 
-  const session = await stripe.checkout.sessions.create(checkoutParams);
+  return checkoutParams;
+}
 
+export async function createStripeCheckoutSession(stripeClient, input) {
+  const session = await stripeClient.checkout.sessions.create(buildStripeCheckoutParams(input));
+  if (!session?.url) throw new Error('Stripe checkout session did not include a URL.');
   return session.url;
 }
 
-export async function createReferralCredit(customerId, { amountCents = 500, currency = 'usd', referredTenantId = '', referrerTenantId = '' } = {}) {
-  if (!stripe) throw new Error('Stripe is not configured.');
-  if (!customerId) throw new Error('Stripe customer is required for referral credit.');
-  return stripe.customers.createBalanceTransaction(customerId, {
-    amount: -Math.abs(Number(amountCents || 0)),
+export async function createCheckoutSession(tenantId, userEmail, planId, successUrl, cancelUrl, metadata = {}, options = {}) {
+  const plan = PLANS[planId];
+  if (!plan?.stripePriceEnv) {
+    throw new BillingError('Choose the Job Seeker or Sales Professional plan.', {
+      code: 'invalid_billing_plan',
+      status: 400,
+    });
+  }
+  if (!stripe || !getStripeConfigStatus().checkoutReady) {
+    throw new BillingError('Checkout is temporarily unavailable. Please contact support.', {
+      code: 'billing_unavailable',
+      status: 503,
+      report: true,
+    });
+  }
+
+  return createStripeCheckoutSession(stripe, {
+    tenantId, userEmail, plan, successUrl, cancelUrl, metadata, customerId: options.customerId,
+  });
+}
+
+export function buildStripeReferralCreditParams({ amountCents = 500, currency = 'usd', referredTenantId = '', referrerTenantId = '' } = {}) {
+  const amount = Math.abs(Number(amountCents));
+  if (!Number.isFinite(amount) || amount <= 0) throw new Error('Referral credit amount must be positive.');
+  return {
+    amount: -amount,
     currency,
     description: 'BD Engine referral credit',
     metadata: {
@@ -301,29 +352,47 @@ export async function createReferralCredit(customerId, { amountCents = 500, curr
       referredTenantId,
       referrerTenantId,
     },
-  });
+  };
 }
 
-export async function createBillingPortalSession(customerId, returnUrl) {
+export async function createStripeReferralCredit(stripeClient, customerId, options = {}) {
+  if (!customerId) throw new Error('Stripe customer is required for referral credit.');
+  return stripeClient.customers.createBalanceTransaction(customerId, buildStripeReferralCreditParams(options));
+}
+
+export async function createReferralCredit(customerId, options = {}) {
   if (!stripe) throw new Error('Stripe is not configured.');
-  
-  const session = await stripe.billingPortal.sessions.create({
+  return createStripeReferralCredit(stripe, customerId, options);
+}
+
+export async function createStripeBillingPortalSession(stripeClient, customerId, returnUrl) {
+  const session = await stripeClient.billingPortal.sessions.create({
     customer: customerId,
     return_url: returnUrl,
   });
-
+  if (!session?.url) throw new Error('Stripe billing portal session did not include a URL.');
   return session.url;
 }
 
-export async function cancelSubscriptionForAccountClosure(subscriptionId) {
-  if (!stripe) throw new Error('Stripe is not configured. The subscription must be canceled before account closure.');
+export async function createBillingPortalSession(customerId, returnUrl) {
+  if (!stripe) {
+    throw new BillingError('The billing portal is temporarily unavailable. Please contact support.', {
+      code: 'billing_unavailable',
+      status: 503,
+      report: true,
+    });
+  }
+  return createStripeBillingPortalSession(stripe, customerId, returnUrl);
+}
+
+export async function cancelStripeSubscription(stripeClient, subscriptionId) {
   if (!subscriptionId) return { canceled: false, alreadyEnded: true };
   try {
-    const existing = await stripe.subscriptions.retrieve(subscriptionId);
+    const existing = await stripeClient.subscriptions.retrieve(subscriptionId);
     if (existing.status === 'canceled') {
       return { canceled: true, alreadyEnded: true, subscriptionId };
     }
-    const canceled = await stripe.subscriptions.cancel(subscriptionId, {
+    const canceled = await stripeClient.subscriptions.cancel(subscriptionId, {
       prorate: false,
       invoice_now: false,
     });
@@ -339,16 +408,44 @@ export async function cancelSubscriptionForAccountClosure(subscriptionId) {
   }
 }
 
+export async function cancelSubscriptionForAccountClosure(subscriptionId) {
+  if (!stripe) throw new Error('Stripe is not configured. The subscription must be canceled before account closure.');
+  return cancelStripeSubscription(stripe, subscriptionId);
+}
+
+export function constructStripeWebhookEvent(stripeClient, payload, signature, endpointSecret) {
+  if (!endpointSecret) throw new Error('Stripe webhook verification is not configured.');
+  try {
+    return stripeClient.webhooks.constructEvent(payload, signature, endpointSecret);
+  } catch (err) {
+    throw new Error('Stripe webhook signature verification failed.', { cause: err });
+  }
+}
+
 export function handleWebhookEvent(payload, signature) {
   if (!stripe) throw new Error('Stripe is not configured.');
-  const endpointSecret = process.env.STRIPE_WEBHOOK_SECRET;
-  
-  let event;
-  try {
-    event = stripe.webhooks.constructEvent(payload, signature, endpointSecret);
-  } catch (err) {
-    throw new Error(`Webhook Error: ${err.message}`, { cause: err });
+  return constructStripeWebhookEvent(stripe, payload, signature, process.env.STRIPE_WEBHOOK_SECRET);
+}
+
+export function getBillingErrorResponse(error, action = 'checkout') {
+  if (error instanceof BillingError) {
+    return { status: error.status, code: error.code, message: error.message, report: error.report };
   }
-  
-  return event;
+  if (error?.code === 'resource_missing') {
+    return {
+      status: 409,
+      code: 'billing_account_missing',
+      message: 'We could not find this workspace billing account. Please contact support.',
+      report: true,
+    };
+  }
+  const portal = action === 'portal';
+  return {
+    status: 502,
+    code: 'billing_provider_unavailable',
+    message: portal
+      ? 'The billing portal is temporarily unavailable. Please try again.'
+      : 'Checkout is temporarily unavailable. Please try again.',
+    report: true,
+  };
 }

--- a/saas/src/server.js
+++ b/saas/src/server.js
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'node:url';
 import { createStore, getRelationalPrimaryTenantIds, registerRelationalPrimaryTenant } from './store.js';
 import { extractSession, createSession, destroySession, forgetUserSessions, isRecentAuthentication, markSessionStepUp, setSessionCookie, clearSessionCookie, loadSessionsFromDb, createPasswordResetSecret, hashPasswordResetToken, verifyPassword } from './auth.js';
 import { createUser, authenticateUser, setUserPassword, markUserEmailVerified, findUserByEmail, findUserById, findTenantsForUser, findTenantById, findTenantBySlug, findTenantByStripeCustomerId, findTenantByReferralCode, findTenantsReferredBy, listTenants, listMemberships, getMembership, addMember, forgetClosedAccount, safeUser, createTenant, ensureTenantForUser, persistUserWorkspace, updateTenant, updateTenantPersisted, loadFromDb as loadUsersFromDb, normalizeReferralCode } from './users.js';
-import { getPlan, getPlanByStripePriceId, getTrialDaysRemaining, getUsageSummary, getEntitlementDecision, PLANS, handleWebhookEvent, createCheckoutSession, createBillingPortalSession, cancelSubscriptionForAccountClosure, createReferralCredit, isStripeConfigured, getStripeConfigStatus, isTrialExpired, createBillingGraceDeadline, getBillingAccessStatus } from './billing.js';
+import { getPlan, getPlanByStripePriceId, getTrialDaysRemaining, getUsageSummary, getEntitlementDecision, PLANS, handleWebhookEvent, createCheckoutSession, createBillingPortalSession, cancelSubscriptionForAccountClosure, createReferralCredit, isStripeConfigured, getStripeConfigStatus, getBillingErrorResponse, isTrialExpired, createBillingGraceDeadline, getBillingAccessStatus } from './billing.js';
 import { initDb, closeDb, isDbEnabled, isDbReady, dbCheckRelationalContentParity, dbCheckRelationalCountParity, dbLoadRelationalPrimaryTenantIds, dbPruneExpiredOperationalData, dbRecordAnalyticsVisit, dbRecordProductEvent, dbRecordAuditLog, dbGetAnalyticsSummary, dbGetImportUsageCount, dbClaimStripeWebhook, dbCompleteStripeWebhook, dbFailStripeWebhook, dbConsumeRateLimit, dbRecordAccountClosure, dbCloseUserAccount, dbSavePasswordResetToken, dbFindPasswordResetToken, dbMarkPasswordResetTokenUsed, dbSaveEmailVerificationToken, dbFindEmailVerificationToken, dbMarkEmailVerificationTokenUsed, dbCreateSupportTicket, dbListSupportTickets, dbGetSupportTicket, dbAddSupportTicketMessage, dbUpdateSupportTicket } from './db.js';
 import { isEmailConfigured, sendPasswordResetEmail, sendEmailVerificationEmail, sendSupportOperatorEmail, sendSupportCustomerReplyEmail } from './email.js';
 import { getReadinessDecision, shouldLogReadinessFailure } from './readiness.js';
@@ -1265,7 +1265,13 @@ self.addEventListener('activate', (event) => {
       });
       return sendJson(res, 200, { url: sessionUrl, mode: 'checkout' });
     } catch (err) {
-      return sendJson(res, 400, { error: err.message });
+      const failure = getBillingErrorResponse(err, 'checkout');
+      if (failure.report) reportServerError(failure.status, req, err);
+      return sendJson(res, failure.status, {
+        error: failure.message,
+        code: failure.code,
+        ...(failure.report ? { requestId: req.requestId } : {}),
+      });
     }
   }
 
@@ -1281,7 +1287,13 @@ self.addEventListener('activate', (event) => {
       const portalUrl = await createBillingPortalSession(customerId, `${getRequestOrigin(req)}/app/#/admin`);
       return sendJson(res, 200, { url: portalUrl });
     } catch (err) {
-      return sendJson(res, 400, { error: err.message });
+      const failure = getBillingErrorResponse(err, 'portal');
+      if (failure.report) reportServerError(failure.status, req, err);
+      return sendJson(res, failure.status, {
+        error: failure.message,
+        code: failure.code,
+        ...(failure.report ? { requestId: req.requestId } : {}),
+      });
     }
   }
 

--- a/saas/test/billing-boundary.test.js
+++ b/saas/test/billing-boundary.test.js
@@ -1,0 +1,227 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import Stripe from 'stripe';
+
+import {
+  BillingError,
+  assessStripeConfig,
+  buildStripeCheckoutParams,
+  buildStripeReferralCreditParams,
+  cancelStripeSubscription,
+  constructStripeWebhookEvent,
+  createStripeBillingPortalSession,
+  createStripeCheckoutSession,
+  createStripeReferralCredit,
+  getBillingErrorResponse,
+} from '../src/billing.js';
+
+const salesPlan = {
+  id: 'sales',
+  displayName: 'Sales Pro',
+  stripePriceEnv: 'STRIPE_PRICE_SALES',
+  stripePriceId: 'price_sales_test',
+};
+
+test('commercial Stripe readiness requires both paid plans', () => {
+  const partial = assessStripeConfig({
+    secretKey: 'sk_live_example',
+    webhookSecret: 'whsec_example',
+    priceIds: { sales: 'price_sales' },
+  });
+  assert.equal(partial.ready, false);
+  assert.equal(partial.commercialReady, false);
+  assert.equal(partial.allPricesConfigured, false);
+  assert.deepEqual(partial.missing, ['STRIPE_PRICE_JOBSEEKER']);
+
+  const complete = assessStripeConfig({
+    secretKey: 'rk_live_example',
+    webhookSecret: 'whsec_example',
+    priceIds: { sales: 'price_sales', jobseeker: 'price_jobseeker' },
+  });
+  assert.equal(complete.checkoutReady, true);
+  assert.equal(complete.commercialReady, true);
+  assert.deepEqual(complete.missing, []);
+});
+
+test('checkout sends one paid plan and tenant metadata to Stripe', async () => {
+  let received;
+  const stripeClient = {
+    checkout: {
+      sessions: {
+        create: async (params) => {
+          received = params;
+          return { url: 'https://checkout.stripe.test/session' };
+        },
+      },
+    },
+  };
+
+  const url = await createStripeCheckoutSession(stripeClient, {
+    tenantId: 'tenant-1',
+    userEmail: 'buyer@example.com',
+    plan: salesPlan,
+    successUrl: 'https://app.example.com/success',
+    cancelUrl: 'https://app.example.com/cancel',
+    metadata: {
+      referralCode: 'REF123',
+      tenantId: 'tenant-overridden',
+      planId: 'owner',
+      empty: '',
+      absent: null,
+    },
+    customerId: 'cus_existing',
+  });
+
+  assert.equal(url, 'https://checkout.stripe.test/session');
+  assert.deepEqual(received.line_items, [{ price: 'price_sales_test', quantity: 1 }]);
+  assert.equal(received.customer, 'cus_existing');
+  assert.equal(Object.hasOwn(received, 'customer_email'), false);
+  assert.deepEqual(received.metadata, { tenantId: 'tenant-1', planId: 'sales', referralCode: 'REF123' });
+  assert.deepEqual(received.subscription_data.metadata, received.metadata);
+
+  const newCustomer = buildStripeCheckoutParams({
+    tenantId: 'tenant-2',
+    userEmail: 'new@example.com',
+    plan: salesPlan,
+    successUrl: 'https://app.example.com/success',
+    cancelUrl: 'https://app.example.com/cancel',
+  });
+  assert.equal(newCustomer.customer_email, 'new@example.com');
+  assert.equal(Object.hasOwn(newCustomer, 'customer'), false);
+  assert.throws(
+    () => buildStripeCheckoutParams({ plan: { id: 'trial' } }),
+    (error) => error instanceof BillingError && error.code === 'invalid_billing_plan'
+  );
+});
+
+test('referral credits use a negative customer balance transaction', async () => {
+  let received;
+  const stripeClient = {
+    customers: {
+      createBalanceTransaction: async (customerId, params) => {
+        received = { customerId, params };
+        return { id: 'cbtxn_1' };
+      },
+    },
+  };
+  const result = await createStripeReferralCredit(stripeClient, 'cus_referrer', {
+    amountCents: 500,
+    referredTenantId: 'tenant-new',
+    referrerTenantId: 'tenant-referrer',
+  });
+  assert.equal(result.id, 'cbtxn_1');
+  assert.equal(received.customerId, 'cus_referrer');
+  assert.equal(received.params.amount, -500);
+  assert.equal(received.params.currency, 'usd');
+  assert.equal(received.params.metadata.source, 'bd_engine_referral');
+  assert.throws(() => buildStripeReferralCreditParams({ amountCents: 0 }), /must be positive/);
+});
+
+test('billing portal sessions preserve the customer and return URL contract', async () => {
+  let received;
+  const stripeClient = {
+    billingPortal: {
+      sessions: {
+        create: async (params) => {
+          received = params;
+          return { url: 'https://billing.stripe.test/session' };
+        },
+      },
+    },
+  };
+  assert.equal(
+    await createStripeBillingPortalSession(stripeClient, 'cus_1', 'https://app.example.com/admin'),
+    'https://billing.stripe.test/session'
+  );
+  assert.deepEqual(received, { customer: 'cus_1', return_url: 'https://app.example.com/admin' });
+});
+
+test('account closure cancellation is idempotent and requires Stripe confirmation', async () => {
+  let cancelCalls = 0;
+  const activeClient = {
+    subscriptions: {
+      retrieve: async () => ({ status: 'active' }),
+      cancel: async (subscriptionId, options) => {
+        cancelCalls += 1;
+        assert.equal(subscriptionId, 'sub_active');
+        assert.deepEqual(options, { prorate: false, invoice_now: false });
+        return { status: 'canceled' };
+      },
+    },
+  };
+  assert.deepEqual(await cancelStripeSubscription(activeClient, 'sub_active'), {
+    canceled: true,
+    alreadyEnded: false,
+    subscriptionId: 'sub_active',
+  });
+  assert.equal(cancelCalls, 1);
+
+  const endedClient = {
+    subscriptions: {
+      retrieve: async () => ({ status: 'canceled' }),
+      cancel: async () => { throw new Error('cancel should not be called'); },
+    },
+  };
+  assert.equal((await cancelStripeSubscription(endedClient, 'sub_ended')).alreadyEnded, true);
+
+  const missingClient = {
+    subscriptions: {
+      retrieve: async () => { throw Object.assign(new Error('missing'), { code: 'resource_missing' }); },
+    },
+  };
+  assert.deepEqual(await cancelStripeSubscription(missingClient, 'sub_missing'), {
+    canceled: true,
+    alreadyEnded: true,
+    subscriptionId: 'sub_missing',
+  });
+
+  const unconfirmedClient = {
+    subscriptions: {
+      retrieve: async () => ({ status: 'active' }),
+      cancel: async () => ({ status: 'active' }),
+    },
+  };
+  await assert.rejects(
+    cancelStripeSubscription(unconfirmedClient, 'sub_unconfirmed'),
+    /did not confirm subscription cancellation/
+  );
+});
+
+test('signed Stripe webhooks reject tampered payloads', () => {
+  const stripeClient = new Stripe('sk_test_signature_only');
+  const endpointSecret = 'whsec_test_signature_secret';
+  const payload = JSON.stringify({
+    id: 'evt_signed',
+    object: 'event',
+    type: 'invoice.paid',
+    data: { object: { id: 'in_1' } },
+  });
+  const signature = stripeClient.webhooks.generateTestHeaderString({
+    payload,
+    secret: endpointSecret,
+    timestamp: Math.floor(Date.now() / 1000),
+  });
+
+  const event = constructStripeWebhookEvent(stripeClient, payload, signature, endpointSecret);
+  assert.equal(event.id, 'evt_signed');
+  assert.equal(event.type, 'invoice.paid');
+  assert.throws(
+    () => constructStripeWebhookEvent(stripeClient, `${payload}tampered`, signature, endpointSecret),
+    /signature verification failed/
+  );
+});
+
+test('billing failures never expose raw provider messages to customers', () => {
+  const missing = Object.assign(new Error('No such customer: cus_private_identifier'), {
+    code: 'resource_missing',
+  });
+  const missingResponse = getBillingErrorResponse(missing, 'portal');
+  assert.equal(missingResponse.status, 409);
+  assert.equal(missingResponse.code, 'billing_account_missing');
+  assert.doesNotMatch(missingResponse.message, /cus_private_identifier|No such customer/);
+
+  const outage = getBillingErrorResponse(new Error('connect ECONNRESET stripe.internal'), 'checkout');
+  assert.equal(outage.status, 502);
+  assert.equal(outage.report, true);
+  assert.doesNotMatch(outage.message, /ECONNRESET|stripe\.internal/);
+});


### PR DESCRIPTION
## Summary
- require both paid Stripe prices before billing reports ready
- map checkout and portal failures to stable customer-safe responses with request IDs
- report provider and configuration failures operationally instead of returning raw Stripe errors as 400s
- extract testable Stripe boundary operations for checkout, portal, referral credits, signed webhooks, and account-closure cancellation
- add an HTTP smoke regression for unavailable checkout
- update launch evidence without claiming live payment exercises

## Verification
- 198/198 SaaS unit and contract tests
- 19/19 focused billing, webhook, and closure tests
- signed Stripe payload accepted; tampered payload rejected
- full local mutable smoke passes
- 22/22 Chromium journeys and accessibility checks
- Chromium, Firefox, and WebKit compatibility passes
- syntax, ESLint, schema contract, and both npm dependency audits pass