### PR TITLE
Keep production integrity reports aggregate only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable customer-facing changes are recorded here. The project is currently 
   provider failures into actionable customer-safe responses, and added direct
   coverage for checkout payloads, signed webhooks, referral credits, portal
   sessions, and subscription cancellation.
+- Removed customer examples, workspace IDs, and internal record IDs from the
+  default semantic-integrity CLI and JSON reports.
 
 - Preserved signup workspace and profile details through first-run setup.
 - Corrected sample-workspace readiness after data is loaded.

--- a/docs/commercial-launch-readiness-2026-07-18.md
+++ b/docs/commercial-launch-readiness-2026-07-18.md
@@ -35,7 +35,7 @@ PowerShell/SQLite edition remains supported separately.
 ## Verified baseline
 
 - SaaS syntax checks: pass.
-- SaaS unit/contract tests: 198/198 pass.
+- SaaS unit/contract tests: 199/199 pass.
 - Chromium customer journeys and accessibility checks: 22/22 pass.
 - Compact compatibility journey: Chromium, Firefox, and WebKit pass.
 - Renderer checks/tests: 4/4 pass.

--- a/saas/OPERATIONS.md
+++ b/saas/OPERATIONS.md
@@ -125,6 +125,9 @@ For an aggregate-only ATS diagnosis that does not print customer records:
 npm.cmd --prefix saas run report:job-coverage -- --tenant <tenant-id>
 ```
 
+Semantic-integrity text and JSON reports are also aggregate-only. They label
+workspaces by sequence and omit customer examples and internal record IDs.
+
 Legacy board records can be linked to an unambiguous normalized-name match with
 a guarded repair. It is dry-run by default. Before applying, create and verify
 a current backup; the exact backup reference is recorded in the audit log.

--- a/saas/scripts/semantic-integrity.mjs
+++ b/saas/scripts/semantic-integrity.mjs
@@ -4,12 +4,12 @@
  * Usage:
  *   node scripts/semantic-integrity.mjs                # all workspaces
  *   node scripts/semantic-integrity.mjs --tenant <id>  # one workspace
- *   node scripts/semantic-integrity.mjs --json         # machine output
+ *   node scripts/semantic-integrity.mjs --json         # aggregate machine output
  *
  * Exits 1 when any workspace has violations (usable as a gate), 0 otherwise.
  */
 import { initDb, dbQuery, closeDb } from '../src/db.js';
-import { checkTenantIntegrity, formatIntegrityReport } from '../src/semantic-integrity.js';
+import { checkTenantIntegrity, formatIntegrityReport, summarizeIntegrityResult } from '../src/semantic-integrity.js';
 
 function arg(name) {
   const i = process.argv.indexOf(name);
@@ -42,9 +42,15 @@ async function main() {
     ]);
     const result = checkTenantIntegrity({ accounts, contacts, jobs, configs });
     totalViolations += result.totalViolations;
-    reports.push({ tenantId, counts: { accounts: accounts.length, contacts: contacts.length, jobs: jobs.length, configs: configs.length }, ...result });
+    const workspace = `workspace ${reports.length + 1}`;
+    const report = {
+      workspace,
+      counts: { accounts: accounts.length, contacts: contacts.length, jobs: jobs.length, configs: configs.length },
+      ...summarizeIntegrityResult(result),
+    };
+    reports.push(report);
     if (!asJson) {
-      console.log(formatIntegrityReport(tenantId, result));
+      console.log(formatIntegrityReport(workspace, report));
     }
   }
 

--- a/saas/src/semantic-integrity.js
+++ b/saas/src/semantic-integrity.js
@@ -167,13 +167,23 @@ export function checkTenantIntegrity({ accounts = [], contacts = [], jobs = [], 
   return { checks, totalViolations };
 }
 
-/** Human-readable one-workspace summary for CLI output. */
-export function formatIntegrityReport(tenantId, result) {
-  const lines = [`${tenantId}: ${result.totalViolations} violation(s)`];
-  for (const [name, check] of Object.entries(result.checks)) {
+export function summarizeIntegrityResult(result) {
+  return {
+    totalViolations: Number(result?.totalViolations || 0),
+    checks: Object.fromEntries(Object.entries(result?.checks || {}).map(([name, check]) => [name, {
+      violations: Number(check?.violations || 0),
+      description: String(check?.description || ''),
+    }])),
+  };
+}
+
+/** Human-readable aggregate summary. Samples may contain customer data. */
+export function formatIntegrityReport(workspaceLabel, result) {
+  const summary = summarizeIntegrityResult(result);
+  const lines = [`${workspaceLabel}: ${summary.totalViolations} violation(s)`];
+  for (const [name, check] of Object.entries(summary.checks)) {
     if (!check.violations) continue;
     lines.push(`  ${name}: ${check.violations} — ${check.description}`);
-    for (const sample of check.sample) lines.push(`    e.g. ${JSON.stringify(sample)}`);
   }
   return lines.join('\n');
 }

--- a/saas/test/semantic-integrity.test.js
+++ b/saas/test/semantic-integrity.test.js
@@ -4,7 +4,7 @@
  */
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { checkTenantIntegrity } from '../src/semantic-integrity.js';
+import { checkTenantIntegrity, formatIntegrityReport, summarizeIntegrityResult } from '../src/semantic-integrity.js';
 
 const cleanWorkspace = () => ({
   accounts: [
@@ -98,4 +98,17 @@ test('board config missing its account link is detected when a match exists', ()
   const result = checkTenantIntegrity(data);
   assert.equal(result.checks.unlinked_board_config.violations, 1);
   assert.equal(result.checks.unlinked_board_config.sample[0].matchingAccountId, 'a1');
+});
+
+test('operator reports omit customer samples and internal identifiers', () => {
+  const data = cleanWorkspace();
+  data.contacts.push({ id: 'contact-private', accountId: 'account-private', fullName: 'Private Person' });
+  const result = checkTenantIntegrity(data);
+  const summary = summarizeIntegrityResult(result);
+  const formatted = formatIntegrityReport('workspace 1', result);
+
+  assert.equal(Object.hasOwn(summary.checks.orphan_contact, 'sample'), false);
+  assert.match(formatted, /workspace 1: 1 violation/);
+  assert.match(formatted, /orphan_contact: 1/);
+  assert.doesNotMatch(formatted, /Private Person|contact-private|account-private|Acme|Alice Ng/);
 });


### PR DESCRIPTION
## Summary
- remove customer examples from semantic-integrity text output
- remove workspace IDs and internal record IDs from text and JSON output
- preserve aggregate counts and violation categories needed for operations
- add a regression test proving private names and IDs never enter formatted reports

## Evidence
A read-only production integrity run exposed sample customer names and internal IDs even though only aggregate diagnostics were needed. The known 12,055 unlinked-board findings remain unchanged and owner-gated; this PR makes no data mutations.

## Verification
- 199/199 unit and contract tests pass
- semantic integrity, sample integrity, and operational script safety tests pass
- syntax, ESLint, and diff checks pass