### PR TITLE
Guard relational write canary mutations

### DIFF
--- a/docs/commercial-launch-readiness-2026-07-18.md
+++ b/docs/commercial-launch-readiness-2026-07-18.md
@@ -35,7 +35,7 @@ PowerShell/SQLite edition remains supported separately.
 ## Verified baseline
 
 - SaaS syntax checks: pass.
-- SaaS unit/contract tests: 203/203 pass.
+- SaaS unit/contract tests: 204/204 pass.
 - Chromium customer journeys and accessibility checks: 22/22 pass.
 - Compact compatibility journey: Chromium, Firefox, and WebKit pass.
 - Renderer checks/tests: 4/4 pass.

--- a/saas/OPERATIONS.md
+++ b/saas/OPERATIONS.md
@@ -154,6 +154,17 @@ npm.cmd --prefix saas run repair:rollups -- --tenant <tenant-id>
 npm.cmd --prefix saas run repair:rollups -- --tenant <tenant-id> --apply --confirm REPAIR_ROLLUPS --backup-reference <backup-id-or-sha>
 ```
 
+Relational write-canary verification is read-only by default. Creating or
+cleaning up the reserved canary requires explicit apply mode, a current backup
+reference, and a mode-specific confirmation. Creation refuses to overwrite an
+existing canary; cleanup only deletes records marked `system_canary`.
+
+```powershell
+npm.cmd --prefix saas run verify:relational-write -- --tenant <tenant-id> --mode verify
+npm.cmd --prefix saas run verify:relational-write -- --tenant <tenant-id> --mode create --apply --confirm CREATE_RELATIONAL_CANARY --backup-reference <backup-id-or-sha>
+npm.cmd --prefix saas run verify:relational-write -- --tenant <tenant-id> --mode cleanup --apply --confirm CLEANUP_RELATIONAL_CANARY --backup-reference <backup-id-or-sha>
+```
+
 ## Backup and restore
 
 Create an encrypted, authenticated, checksummed application backup before

--- a/saas/scripts/verify-relational-write-canary.mjs
+++ b/saas/scripts/verify-relational-write-canary.mjs
@@ -1,6 +1,7 @@
 import { closeDb, dbCheckRelationalContentParity, dbQuery, initDb } from '../src/db.js';
 import { createStore, flushPendingSaves } from '../src/store.js';
 import { findTenantById, loadFromDb as loadUsersFromDb } from '../src/users.js';
+import { requireMaintenanceApproval } from '../src/maintenance-safety.js';
 
 const CANARY_ID = 'cfg-relational-write-canary';
 const CANARY_ATS = 'relational_canary';
@@ -22,7 +23,20 @@ async function prepareStore(tenantId) {
 async function createCanary(tenantId) {
   const store = await prepareStore(tenantId);
   await store.getBootstrap(tenantId, { includeFilters: true });
-  await dbQuery('DELETE FROM board_configs WHERE tenant_id = $1 AND id = $2', [tenantId, CANARY_ID]);
+  const existing = await dbQuery(
+    `SELECT
+       (SELECT COUNT(*)::int FROM board_configs WHERE tenant_id = $1 AND id = $2) AS relational_count,
+       (SELECT COUNT(*)::int FROM tenant_data
+        WHERE tenant_id = $1 AND EXISTS (
+          SELECT 1 FROM jsonb_array_elements(COALESCE(configs, '[]'::jsonb)) item
+          WHERE item->>'id' = $2
+        )) AS legacy_count`,
+    [tenantId, CANARY_ID]
+  );
+  const existingRow = existing?.rows?.[0] || {};
+  if (Number(existingRow.relational_count || 0) || Number(existingRow.legacy_count || 0)) {
+    throw new Error('A relational write canary already exists. Verify or clean it up before creating another.');
+  }
   store.addConfig(tenantId, {
     id: CANARY_ID,
     companyName: 'Relational write canary',
@@ -67,7 +81,9 @@ async function verifyCanary(tenantId) {
 async function cleanupCanary(tenantId) {
   const result = await dbQuery(
     `DELETE FROM board_configs
-     WHERE tenant_id = $1 AND (id = $2 OR id LIKE 'cfg-write-canary-%')`,
+     WHERE tenant_id = $1
+       AND (id = $2 OR id LIKE 'cfg-write-canary-%')
+       AND raw->>'source' = 'system_canary'`,
     [tenantId, CANARY_ID]
   );
   const parity = await dbCheckRelationalContentParity([tenantId]);
@@ -78,9 +94,21 @@ async function cleanupCanary(tenantId) {
 async function main() {
   const tenantId = arg('--tenant');
   const mode = arg('--mode') || 'verify';
+  const apply = process.argv.includes('--apply');
   if (!tenantId) throw new Error('Pass --tenant <tenant-id>.');
   if (!['create', 'verify', 'cleanup'].includes(mode)) throw new Error('Pass --mode create, verify, or cleanup.');
-  if (!(await initDb({ migrate: false, readOnly: mode === 'verify' }))) throw new Error('DATABASE_URL is required.');
+  const mutating = mode !== 'verify';
+  if (mutating && !apply) throw new Error(`${mode} mode requires --apply.`);
+  if (!mutating && apply) throw new Error('Verify mode is read-only; remove --apply.');
+  requireMaintenanceApproval({
+    apply: mutating,
+    tenantId,
+    confirmation: String(arg('--confirm') || ''),
+    expectedConfirmation: mode === 'create' ? 'CREATE_RELATIONAL_CANARY' : 'CLEANUP_RELATIONAL_CANARY',
+    backupReference: String(arg('--backup-reference') || ''),
+    action: `${mode === 'create' ? 'Creating' : 'Cleaning up'} the relational write canary`,
+  });
+  if (!(await initDb({ migrate: false, readOnly: !mutating }))) throw new Error('DATABASE_URL is required.');
 
   const result = mode === 'create'
     ? await createCanary(tenantId)

--- a/saas/test/operational-script-safety.test.js
+++ b/saas/test/operational-script-safety.test.js
@@ -93,6 +93,17 @@ test('rollup repair is atomic across relational, legacy, and audit storage', asy
   assert.doesNotMatch(source, /dbQuery\('BEGIN'/u);
 });
 
+test('relational write canary fails closed before mutating a workspace', async () => {
+  const source = await scriptSource('verify-relational-write-canary.mjs');
+  assert.match(source, /mutating && !apply/u);
+  assert.match(source, /CREATE_RELATIONAL_CANARY/u);
+  assert.match(source, /CLEANUP_RELATIONAL_CANARY/u);
+  assert.match(source, /backupReference/iu);
+  assert.match(source, /A relational write canary already exists/u);
+  assert.doesNotMatch(source, /DELETE FROM board_configs WHERE tenant_id = \$1 AND id = \$2/u);
+  assert.match(source, /raw->>'source' = 'system_canary'/u);
+});
+
 test('routine maintenance output omits direct customer identifiers', async () => {
   const scripts = [
     'backfill-relational.mjs',


### PR DESCRIPTION
## Summary
- require `--apply`, mode-specific exact confirmation, explicit workspace scope, and a verified backup reference for write-canary create/cleanup
- reject ambiguous verify/apply combinations before database access
- fail closed on existing canaries instead of deleting the reserved ID first
- restrict cleanup to records marked as system canaries

## Verification
- `npm run check`
- `npm run lint`
- `npm test` (204/204)
- unsafe CLI forms rejected before database connection