### PR TITLE
Record production alert routing evidence

### DIFF
--- a/docs/commercial-launch-checklist.md
+++ b/docs/commercial-launch-checklist.md
@@ -29,9 +29,11 @@ and durable evidence link or identifier. Never paste secrets or customer rows.
 - [ ] `BD_SUPPORT_ADMIN_EMAILS` names an accountable, least-privilege support
   group. Access was tested after the 15-minute password step-up expired.
   Evidence: `________________`
-- [ ] `BD_ERROR_WEBHOOK` reaches an actively monitored destination; a controlled
+- [x] `BD_ERROR_WEBHOOK` reaches an actively monitored destination; a controlled
   synthetic failure was received with release and request IDs but no customer data.
-  Evidence: `________________`
+  Evidence: 2026-07-19, private Discord `bd-engine-alerts` channel. Railway
+  production environment delivered the value-safe synthetic request
+  `synthetic-setup-20260719` with HTTP 204, and the alert was observed in-channel.
 - [ ] `BD_REQUIRE_EMAIL_VERIFICATION=true` and an unverified test account was
   blocked from import, discovery, and renderer-backed work. Evidence: `________________`
 - [ ] The value-safe check passes without printing values:

--- a/docs/commercial-launch-readiness-2026-07-18.md
+++ b/docs/commercial-launch-readiness-2026-07-18.md
@@ -84,7 +84,10 @@ PowerShell/SQLite edition remains supported separately.
 
 1. `BD_SUPPORT_ADMIN_EMAILS` is active for the named operator, but the full
    support step-up workflow still needs a production test. `BD_ERROR_WEBHOOK`
-   remains unset, so server failures still lack accountable real-time routing.
+   now routes production alerts to a private Discord channel; a value-safe
+   synthetic alert from the Railway production environment was observed on
+   2026-07-19. Ongoing channel ownership and response-time expectations still
+   need to be documented before a broad launch.
 2. Both live Stripe prices and products are active with the advertised monthly
    USD amounts. The canonical webhook is enabled for all six required checkout,
    subscription, failed-payment, and recovery events, and the read-only catalog


### PR DESCRIPTION
## Summary
- record the private Discord production alert destination
- record the value-safe Railway synthetic delivery check
- update the readiness report now that real-time routing is active

## Verification
- Railway production configuration deployed successfully
- `/health`, `/livez`, and `/readyz` returned HTTP 200
- Discord accepted the webhook request with HTTP 204 and displayed the synthetic request ID
- no secret values or customer data are included