### PR TITLE
Expand ATS checker into a coverage audit

### DIFF
--- a/saas/public/ats-checker.css
+++ b/saas/public/ats-checker.css
@@ -125,6 +125,7 @@ h1 {
 }
 
 .checker-panel {
+  min-width: 0;
   padding: 28px;
   border: 1px solid var(--border);
   border-radius: 8px;
@@ -144,22 +145,25 @@ label {
   gap: 10px;
 }
 
-input,
+textarea,
 button {
   min-height: 48px;
   border-radius: 7px;
   font: inherit;
 }
 
-input {
+textarea {
   width: 100%;
-  padding: 0 14px;
+  min-height: 174px;
+  padding: 13px 14px;
   border: 1px solid #40506c;
   background: #0b1220;
   color: #ffffff;
+  line-height: 1.5;
+  resize: vertical;
 }
 
-input:focus-visible,
+textarea:focus-visible,
 button:focus-visible,
 a:focus-visible {
   outline: 3px solid rgba(63, 131, 248, 0.42);
@@ -167,6 +171,7 @@ a:focus-visible {
 }
 
 button {
+  align-self: end;
   padding: 0 20px;
   border: 1px solid var(--accent);
   background: var(--accent-strong);
@@ -193,6 +198,7 @@ footer {
 }
 
 .checker-result {
+  min-width: 0;
   margin-top: 24px;
   padding-top: 24px;
   border-top: 1px solid var(--border);
@@ -227,6 +233,129 @@ footer {
   line-height: 1.6;
 }
 
+.coverage-summary {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin: 24px 0;
+  border-block: 1px solid var(--border);
+}
+
+.coverage-summary > div {
+  padding: 16px 12px;
+}
+
+.coverage-summary > div + div {
+  border-left: 1px solid var(--border);
+}
+
+.coverage-summary dt {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.coverage-summary dd {
+  margin: 6px 0 0;
+  color: #ffffff;
+  font-size: 24px;
+  font-weight: 800;
+}
+
+.audit-note {
+  margin-bottom: 18px;
+  font-size: 13px;
+}
+
+.audit-table-wrap {
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+}
+
+.audit-table-wrap[hidden] {
+  display: none;
+}
+
+table {
+  width: 100%;
+  min-width: 590px;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+th,
+td {
+  padding: 13px 14px;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+  vertical-align: top;
+}
+
+th {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 750;
+  text-transform: uppercase;
+}
+
+tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.submitted-url,
+.hostname {
+  display: block;
+  max-width: 390px;
+  overflow-wrap: anywhere;
+}
+
+.hostname {
+  margin-top: 4px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.audit-status {
+  display: inline-flex;
+  padding: 4px 8px;
+  border-radius: 6px;
+  background: rgba(169, 180, 200, 0.12);
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 750;
+  white-space: nowrap;
+}
+
+.audit-status-recognized {
+  background: rgba(52, 211, 153, 0.12);
+  color: var(--success);
+}
+
+.audit-status-review {
+  background: rgba(251, 191, 36, 0.12);
+  color: var(--warning);
+}
+
+.audit-status-invalid {
+  background: rgba(251, 113, 133, 0.12);
+  color: var(--danger);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .result-actions {
   display: flex;
   flex-wrap: wrap;
@@ -234,7 +363,8 @@ footer {
   margin-top: 20px;
 }
 
-.result-actions a {
+.result-actions a,
+.result-actions button {
   display: inline-flex;
   min-height: 42px;
   align-items: center;
@@ -247,7 +377,15 @@ footer {
   text-decoration: none;
 }
 
-.result-actions a:first-child {
+.result-actions button {
+  background: transparent;
+}
+
+.result-actions button:hover {
+  background: #1b2b45;
+}
+
+.result-actions .primary-workflow {
   border-color: var(--accent);
   background: #142b50;
 }
@@ -260,6 +398,12 @@ footer {
 .coverage-notes h2 {
   color: #ffffff;
   font-size: 26px;
+}
+
+.coverage-notes h3 {
+  margin: 28px 0 10px;
+  color: #ffffff;
+  font-size: 16px;
 }
 
 .coverage-notes ul {
@@ -316,6 +460,70 @@ footer {
 
   .input-row {
     grid-template-columns: 1fr;
+  }
+
+  .coverage-summary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .coverage-summary > div:nth-child(3) {
+    border-left: 0;
+    border-top: 1px solid var(--border);
+  }
+
+  .coverage-summary > div:nth-child(4) {
+    border-top: 1px solid var(--border);
+  }
+
+  table {
+    min-width: 0;
+  }
+
+  thead {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  tbody,
+  tbody tr,
+  tbody td {
+    display: block;
+  }
+
+  tbody tr {
+    padding: 11px 13px;
+    border-bottom: 1px solid var(--border);
+  }
+
+  tbody tr:last-child {
+    border-bottom: 0;
+  }
+
+  tbody td {
+    padding: 6px 0;
+    border: 0;
+  }
+
+  tbody td::before {
+    display: block;
+    margin-bottom: 4px;
+    color: var(--muted);
+    content: attr(data-label);
+    font-size: 10px;
+    font-weight: 750;
+    text-transform: uppercase;
+  }
+
+  .submitted-url,
+  .hostname {
+    max-width: none;
   }
 
   footer {

--- a/saas/public/ats-checker.html
+++ b/saas/public/ats-checker.html
@@ -3,31 +3,31 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="Check whether a public career-site URL matches an ATS provider supported by BD Engine, with clear coverage caveats.">
+  <meta name="description" content="Audit up to 50 public career-site URLs against ATS providers recognized by BD Engine, with an explicit denominator and CSV export.">
   <meta name="robots" content="index, follow, max-image-preview:large">
   <link rel="canonical" href="https://bd-engine-production.up.railway.app/ats-checker">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="BD Engine Cloud">
-  <meta property="og:title" content="Free ATS Compatibility Checker | BD Engine">
-  <meta property="og:description" content="Identify whether a public career-site URL matches a supported ATS provider. No signup required.">
+  <meta property="og:title" content="Free Bulk ATS Coverage Checker | BD Engine">
+  <meta property="og:description" content="Audit up to 50 public career-site URLs, see the recognized-host rate, and export the results. No signup required.">
   <meta property="og:url" content="https://bd-engine-production.up.railway.app/ats-checker">
   <meta property="og:image" content="https://bd-engine-production.up.railway.app/bd-engine-logo.png">
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="Free ATS Compatibility Checker | BD Engine">
-  <meta name="twitter:description" content="Check a public career-site URL against BD Engine's supported ATS providers.">
+  <meta name="twitter:title" content="Free Bulk ATS Coverage Checker | BD Engine">
+  <meta name="twitter:description" content="Audit a target list against the public ATS hosts recognized by BD Engine.">
   <meta name="twitter:image" content="https://bd-engine-production.up.railway.app/bd-engine-logo.png">
   <meta name="theme-color" content="#080d18">
-  <title>Free ATS Compatibility Checker | BD Engine</title>
+  <title>Free Bulk ATS Coverage Checker | BD Engine</title>
   <link rel="stylesheet" href="/ats-checker.css">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "WebApplication",
-    "name": "BD Engine ATS Compatibility Checker",
+    "name": "BD Engine Bulk ATS Coverage Checker",
     "applicationCategory": "BusinessApplication",
     "operatingSystem": "Web",
     "url": "https://bd-engine-production.up.railway.app/ats-checker",
-    "description": "A free browser-based check for public career-site URLs that match ATS providers supported by BD Engine.",
+    "description": "A free browser-based audit for up to 50 public career-site URLs that match ATS providers recognized by BD Engine.",
     "offers": {
       "@type": "Offer",
       "price": "0",
@@ -51,35 +51,52 @@
   <main>
     <section class="checker-intro" aria-labelledby="checker-title">
       <p class="eyebrow">Free public utility</p>
-      <h1 id="checker-title">Check a public career-site URL</h1>
-      <p class="lede">See whether a URL matches an ATS provider that BD Engine can work with. The check runs in your browser and does not fetch the submitted site.</p>
+      <h1 id="checker-title">Audit ATS coverage for a target list</h1>
+      <p class="lede">Paste one or many public career-site URLs to see the recognized-host rate for your list. The check runs in your browser and does not fetch the submitted site.</p>
     </section>
 
     <div class="checker-layout">
-      <section class="checker-panel" aria-label="ATS compatibility check">
+      <section class="checker-panel" aria-label="ATS coverage audit">
         <form id="ats-checker-form" novalidate>
-          <label for="career-url">Career site or job-board URL</label>
+          <label for="career-urls">Career-site or job-board URLs</label>
           <div class="input-row">
-            <input id="career-url" name="careerUrl" type="text" inputmode="url" autocomplete="url" placeholder="https://jobs.example.com/company" required aria-describedby="url-help">
-            <button type="submit">Check URL</button>
+            <textarea id="career-urls" name="careerUrls" rows="7" spellcheck="false" placeholder="https://boards.greenhouse.io/example&#10;https://jobs.lever.co/example&#10;https://example.com/careers" required aria-describedby="url-help"></textarea>
+            <button type="submit">Audit coverage</button>
           </div>
-          <p id="url-help" class="field-help">Use a public company careers page or hosted ATS board. Do not enter login links or private systems.</p>
+          <p id="url-help" class="field-help">Enter one public URL per line, up to 50. Duplicate lines are removed. Do not enter login links or private systems.</p>
         </form>
 
         <div id="checker-result" class="checker-result" role="status" aria-live="polite" hidden>
           <p id="result-status" class="result-status"></p>
           <h2 id="result-title"></h2>
           <p id="result-message"></p>
+          <dl id="coverage-summary" class="coverage-summary"></dl>
+          <p id="audit-note" class="audit-note" hidden></p>
+          <div id="audit-table-wrap" class="audit-table-wrap" hidden>
+            <table>
+              <caption class="sr-only">ATS host recognition results</caption>
+              <thead>
+                <tr>
+                  <th scope="col">Career URL</th>
+                  <th scope="col">Result</th>
+                  <th scope="col">Provider</th>
+                </tr>
+              </thead>
+              <tbody id="audit-rows" role="rowgroup"></tbody>
+            </table>
+          </div>
           <div id="result-actions" class="result-actions"></div>
         </div>
       </section>
 
       <aside class="coverage-notes" aria-labelledby="coverage-title">
-        <p class="eyebrow">What this checks</p>
-        <h2 id="coverage-title">Recognized public providers</h2>
+        <p class="eyebrow">What the rate means</p>
+        <h2 id="coverage-title">A defined denominator</h2>
+        <p>The reported percentage is recognized ATS hosts divided by valid public URLs in this audit. Invalid entries are shown but excluded from the rate.</p>
+        <h3>Recognized public providers</h3>
         <p>Greenhouse, Lever, Ashby, SmartRecruiters, Workday, BambooHR, Workable, Jobvite, Recruitee, Personio, and Rippling.</p>
         <ul>
-          <li>A recognized host is a compatibility signal, not a coverage guarantee.</li>
+          <li>A recognized host is a compatibility signal, not a coverage guarantee or confirmation of role count and freshness.</li>
           <li>Employers can change, hide, or customize public career pages.</li>
           <li>Ordinary company careers pages may still need discovery and review.</li>
         </ul>

--- a/saas/public/ats-checker.js
+++ b/saas/public/ats-checker.js
@@ -14,17 +14,17 @@ const PROVIDERS = [
 
 export function classifyCareerUrl(value) {
   const raw = String(value || '').trim();
-  if (!raw) return { status: 'invalid', title: 'Enter a public URL', tone: 'error' };
+  if (!raw) return { status: 'invalid', submittedUrl: raw, title: 'Enter a public URL', tone: 'error' };
 
   let parsed;
   try {
     parsed = new URL(/^https?:\/\//i.test(raw) ? raw : `https://${raw}`);
   } catch {
-    return { status: 'invalid', title: 'That URL could not be read', tone: 'error' };
+    return { status: 'invalid', submittedUrl: raw, title: 'That URL could not be read', tone: 'error' };
   }
 
-  if (!['http:', 'https:'].includes(parsed.protocol) || !isPublicHostname(parsed.hostname)) {
-    return { status: 'invalid', title: 'Use a public career-site URL', tone: 'error' };
+  if (!['http:', 'https:'].includes(parsed.protocol) || parsed.username || parsed.password || !isPublicHostname(parsed.hostname)) {
+    return { status: 'invalid', submittedUrl: raw, title: 'Use a public career-site URL', tone: 'error' };
   }
 
   const hostname = parsed.hostname.toLowerCase().replace(/^www\./, '');
@@ -34,6 +34,7 @@ export function classifyCareerUrl(value) {
         status: 'recognized',
         provider,
         hostname,
+        submittedUrl: raw,
         title: `${provider} provider detected`,
         tone: 'success',
       };
@@ -43,9 +44,68 @@ export function classifyCareerUrl(value) {
   return {
     status: 'review',
     hostname,
+    submittedUrl: raw,
     title: 'Discovery and review are still needed',
     tone: 'review',
   };
+}
+
+export function buildCoverageAudit(value, maxEntries = 50) {
+  const limit = Math.min(50, Math.max(1, Number.parseInt(maxEntries, 10) || 50));
+  const lines = String(value || '')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const seen = new Set();
+  const unique = [];
+  let duplicateCount = 0;
+
+  for (const line of lines) {
+    const key = line.toLowerCase().replace(/\/$/, '');
+    if (seen.has(key)) {
+      duplicateCount += 1;
+      continue;
+    }
+    seen.add(key);
+    unique.push(line);
+  }
+
+  const results = unique.slice(0, limit).map(classifyCareerUrl);
+  const recognizedCount = results.filter((result) => result.status === 'recognized').length;
+  const reviewCount = results.filter((result) => result.status === 'review').length;
+  const invalidCount = results.filter((result) => result.status === 'invalid').length;
+  const validCount = recognizedCount + reviewCount;
+
+  return {
+    results,
+    totalCount: results.length,
+    validCount,
+    recognizedCount,
+    reviewCount,
+    invalidCount,
+    recognitionRate: validCount ? Math.round((recognizedCount / validCount) * 100) : 0,
+    duplicateCount,
+    truncatedCount: Math.max(0, unique.length - limit),
+  };
+}
+
+function csvCell(value) {
+  let text = String(value ?? '');
+  if (/^[=+\-@]/.test(text)) text = `'${text}`;
+  return `"${text.replace(/"/g, '""')}"`;
+}
+
+export function buildCoverageCsv(audit) {
+  const rows = [['Submitted URL', 'Host', 'Result', 'Provider']];
+  for (const result of audit?.results || []) {
+    rows.push([
+      result.submittedUrl,
+      result.hostname || '',
+      result.status === 'recognized' ? 'Recognized' : result.status === 'review' ? 'Needs discovery' : 'Invalid',
+      result.provider || '',
+    ]);
+  }
+  return rows.map((row) => row.map(csvCell).join(',')).join('\r\n');
 }
 
 function isPublicHostname(hostname) {
@@ -58,37 +118,149 @@ function isPublicHostname(hostname) {
   return normalized.includes('.');
 }
 
-function renderResult(result) {
+function countLabel(count, singular, plural = `${singular}s`) {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function appendMetric(container, label, value) {
+  const wrapper = document.createElement('div');
+  const term = document.createElement('dt');
+  const description = document.createElement('dd');
+  term.textContent = label;
+  description.textContent = value;
+  wrapper.append(term, description);
+  container.append(wrapper);
+}
+
+function resultLabel(result) {
+  if (result.status === 'recognized') return 'Recognized';
+  if (result.status === 'review') return 'Needs discovery';
+  return 'Invalid';
+}
+
+function renderAuditRows(audit) {
+  const tableWrap = document.getElementById('audit-table-wrap');
+  const rows = document.getElementById('audit-rows');
+  if (!tableWrap || !rows) return;
+  rows.replaceChildren();
+  tableWrap.hidden = audit.totalCount === 0;
+
+  for (const result of audit.results) {
+    const row = document.createElement('tr');
+    row.setAttribute('role', 'row');
+    const urlCell = document.createElement('td');
+    urlCell.setAttribute('role', 'cell');
+    urlCell.dataset.label = 'Career URL';
+    const submitted = document.createElement('span');
+    submitted.className = 'submitted-url';
+    submitted.textContent = result.submittedUrl;
+    urlCell.append(submitted);
+    if (result.hostname) {
+      const hostname = document.createElement('span');
+      hostname.className = 'hostname';
+      hostname.textContent = result.hostname;
+      urlCell.append(hostname);
+    }
+
+    const statusCell = document.createElement('td');
+    statusCell.setAttribute('role', 'cell');
+    statusCell.dataset.label = 'Result';
+    const status = document.createElement('span');
+    status.className = `audit-status audit-status-${result.status}`;
+    status.textContent = resultLabel(result);
+    statusCell.append(status);
+
+    const providerCell = document.createElement('td');
+    providerCell.setAttribute('role', 'cell');
+    providerCell.dataset.label = 'Provider';
+    providerCell.textContent = result.provider || (result.status === 'review' ? 'Unknown host' : 'Not applicable');
+    row.append(urlCell, statusCell, providerCell);
+    rows.append(row);
+  }
+}
+
+function downloadCoverageCsv(audit) {
+  const blob = new Blob([buildCoverageCsv(audit)], { type: 'text/csv;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = 'bd-engine-ats-coverage-audit.csv';
+  document.body.append(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}
+
+function renderResult(audit) {
   const container = document.getElementById('checker-result');
   const status = document.getElementById('result-status');
   const title = document.getElementById('result-title');
   const message = document.getElementById('result-message');
+  const summary = document.getElementById('coverage-summary');
+  const note = document.getElementById('audit-note');
   const actions = document.getElementById('result-actions');
-  if (!container || !status || !title || !message || !actions) return;
+  if (!container || !status || !title || !message || !summary || !note || !actions) return;
 
   container.hidden = false;
-  container.dataset.tone = result.tone;
-  status.textContent = result.status === 'recognized'
-    ? 'Recognized provider'
-    : result.status === 'review'
-      ? 'Needs discovery'
-      : 'Check the URL';
-  title.textContent = result.title;
-  message.textContent = result.status === 'recognized'
-    ? 'This host matches a provider BD Engine supports. The board must still be public and accessible, and role completeness can vary by employer configuration.'
-    : result.status === 'review'
-      ? 'This appears to be an ordinary company or careers URL. BD Engine may be able to discover a compatible public board from it, but this browser-only check cannot confirm coverage.'
-      : 'Enter a public company careers page or hosted job-board URL. Nothing is fetched or submitted by this checker.';
+  const singleResult = audit.results.length === 1 ? audit.results[0] : null;
+  const hasValidUrls = audit.validCount > 0;
+  container.dataset.tone = !audit.totalCount || !hasValidUrls
+    ? 'error'
+    : audit.recognizedCount === audit.validCount
+      ? 'success'
+      : 'review';
+  status.textContent = !audit.totalCount
+    ? 'Add a target list'
+    : !hasValidUrls
+      ? 'Check the entries'
+      : audit.recognizedCount === audit.validCount
+        ? 'All valid hosts recognized'
+        : audit.recognizedCount
+          ? 'Mixed host coverage'
+          : 'Discovery required';
+  title.textContent = !audit.totalCount
+    ? 'Enter at least one public URL'
+    : singleResult?.status === 'recognized'
+      ? singleResult.title
+      : singleResult?.status === 'review'
+        ? singleResult.title
+        : !hasValidUrls
+          ? 'No valid public URLs to audit'
+          : `${audit.recognizedCount} of ${audit.validCount} valid public URLs match a recognized ATS host`;
+  message.textContent = !audit.totalCount
+    ? 'Enter one public company careers page or hosted job-board URL per line. Nothing is fetched or submitted by this checker.'
+    : !hasValidUrls
+      ? 'Use public HTTP or HTTPS career-site URLs. Login links, private systems, and unreadable entries are excluded from the denominator.'
+      : `Host recognition is ${audit.recognitionRate}%: ${audit.recognizedCount} recognized out of ${audit.validCount} valid public URLs. ${countLabel(audit.reviewCount, 'URL')} ${audit.reviewCount === 1 ? 'needs' : 'need'} discovery, and ${countLabel(audit.invalidCount, 'entry', 'entries')} ${audit.invalidCount === 1 ? 'was' : 'were'} invalid. Recognition identifies the host, not the number or freshness of relevant roles.`;
+
+  summary.replaceChildren();
+  appendMetric(summary, 'Audited', String(audit.totalCount));
+  appendMetric(summary, 'Valid public URLs', String(audit.validCount));
+  appendMetric(summary, 'Recognized ATS', String(audit.recognizedCount));
+  appendMetric(summary, 'Host recognition', `${audit.recognitionRate}%`);
+
+  const notes = [];
+  if (audit.duplicateCount) notes.push(`${countLabel(audit.duplicateCount, 'duplicate')} removed`);
+  if (audit.truncatedCount) notes.push(`${countLabel(audit.truncatedCount, 'entry', 'entries')} beyond the 50-URL limit not audited`);
+  note.textContent = notes.length ? `${notes.join('. ')}.` : '';
+  note.hidden = notes.length === 0;
+  renderAuditRows(audit);
   actions.replaceChildren();
 
-  if (result.status !== 'invalid') {
+  if (hasValidUrls) {
+    const exportButton = document.createElement('button');
+    exportButton.type = 'button';
+    exportButton.className = 'export-action';
+    exportButton.textContent = 'Download CSV';
+    exportButton.addEventListener('click', () => downloadCoverageCsv(audit));
     const staffingLink = document.createElement('a');
-    staffingLink.href = '/?utm_source=ats-checker&utm_medium=tool&utm_campaign=checker_result';
-    staffingLink.textContent = 'Open staffing workflow';
+    staffingLink.href = '/?utm_source=ats-checker&utm_medium=tool&utm_campaign=coverage_audit_result';
+    staffingLink.className = 'primary-workflow';
+    staffingLink.textContent = 'Prioritize target companies';
     const jobSearchLink = document.createElement('a');
-    jobSearchLink.href = '/job-search?utm_source=ats-checker&utm_medium=tool&utm_campaign=checker_result';
-    jobSearchLink.textContent = 'Open job-search workflow';
-    actions.append(staffingLink, jobSearchLink);
+    jobSearchLink.href = '/job-search?utm_source=ats-checker&utm_medium=tool&utm_campaign=coverage_audit_result';
+    jobSearchLink.textContent = 'Find relevant roles';
+    actions.append(exportButton, staffingLink, jobSearchLink);
   }
 }
 
@@ -135,8 +307,8 @@ function trackCheckerEvent(eventType = 'pageview') {
 if (typeof document !== 'undefined') {
   document.getElementById('ats-checker-form')?.addEventListener('submit', (event) => {
     event.preventDefault();
-    const input = document.getElementById('career-url');
-    renderResult(classifyCareerUrl(input?.value));
+    const input = document.getElementById('career-urls');
+    renderResult(buildCoverageAudit(input?.value));
     trackCheckerEvent('tool_used');
   });
   trackCheckerEvent();

--- a/saas/test/ats-checker.test.js
+++ b/saas/test/ats-checker.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { classifyCareerUrl } from '../public/ats-checker.js';
+import { buildCoverageAudit, buildCoverageCsv, classifyCareerUrl } from '../public/ats-checker.js';
 
 test('ATS checker recognizes every provider advertised on the public page', () => {
   const examples = [
@@ -35,4 +35,38 @@ test('ATS checker rejects invalid and private destinations', () => {
   assert.equal(classifyCareerUrl('http://localhost:8787').status, 'invalid');
   assert.equal(classifyCareerUrl('http://192.168.1.5/jobs').status, 'invalid');
   assert.equal(classifyCareerUrl('not a url').status, 'invalid');
+});
+
+test('ATS coverage audit reports an explicit valid-URL denominator', () => {
+  const audit = buildCoverageAudit([
+    'https://boards.greenhouse.io/example',
+    'https://jobs.lever.co/example',
+    'https://example.com/careers',
+    'http://localhost:8787',
+    'https://boards.greenhouse.io/example/',
+  ].join('\n'));
+
+  assert.equal(audit.totalCount, 4);
+  assert.equal(audit.validCount, 3);
+  assert.equal(audit.recognizedCount, 2);
+  assert.equal(audit.reviewCount, 1);
+  assert.equal(audit.invalidCount, 1);
+  assert.equal(audit.recognitionRate, 67);
+  assert.equal(audit.duplicateCount, 1);
+});
+
+test('ATS coverage audit enforces its 50-entry browser limit', () => {
+  const urls = Array.from({ length: 52 }, (_, index) => `https://company-${index}.example.com/careers`);
+  const audit = buildCoverageAudit(urls.join('\n'));
+
+  assert.equal(audit.totalCount, 50);
+  assert.equal(audit.truncatedCount, 2);
+});
+
+test('ATS coverage CSV exports every audited row and neutralizes formulas', () => {
+  const audit = buildCoverageAudit('https://jobs.ashbyhq.com/example\n=not-a-url');
+  const csv = buildCoverageCsv(audit);
+
+  assert.match(csv, /"https:\/\/jobs\.ashbyhq\.com\/example","jobs\.ashbyhq\.com","Recognized","Ashby"/);
+  assert.match(csv, /"'=not-a-url","","Invalid",""/);
 });

--- a/saas/test/browser/accessibility.spec.mjs
+++ b/saas/test/browser/accessibility.spec.mjs
@@ -23,6 +23,19 @@ test('public account entry is accessible', async ({ page }) => {
   await expectNoBlockingViolations(page);
 });
 
+test('ATS coverage audit is accessible before and after results render', async ({ page }) => {
+  await page.goto('/ats-checker');
+  await expectNoBlockingViolations(page);
+
+  await page.getByLabel('Career-site or job-board URLs').fill([
+    'https://boards.greenhouse.io/example',
+    'https://example.com/careers',
+  ].join('\n'));
+  await page.getByRole('button', { name: 'Audit coverage' }).click();
+  await expect(page.getByRole('heading', { name: '1 of 2 valid public URLs match a recognized ATS host' })).toBeVisible();
+  await expectNoBlockingViolations(page);
+});
+
 test('demo workspace has no blocking structural accessibility violations', async ({ page }) => {
   await page.goto('/');
   await page.locator('[data-demo-start]').first().click();

--- a/saas/test/browser/discoverability.spec.mjs
+++ b/saas/test/browser/discoverability.spec.mjs
@@ -39,26 +39,41 @@ test('clean job-search route publishes focused metadata and campaign attribution
   expect(source).toMatchObject({ source: 'linkedin', campaign: 'role_focus' });
 });
 
-test('ATS checker recognizes supported hosts and explains uncertain pages', async ({ page }) => {
+test('ATS checker audits a target list with an explicit denominator', async ({ page }) => {
   await page.goto('/ats-checker');
-  const input = page.getByLabel('Career site or job-board URL');
+  const input = page.getByLabel('Career-site or job-board URLs');
 
-  await input.fill('https://boards.greenhouse.io/example');
-  await page.getByRole('button', { name: 'Check URL' }).click();
-  await expect(page.getByRole('heading', { name: 'Greenhouse provider detected' })).toBeVisible();
-  await expect(page.getByText(/not a coverage guarantee/i)).toBeVisible();
-
-  await input.fill('https://example.com/careers');
-  await page.getByRole('button', { name: 'Check URL' }).click();
-  await expect(page.getByRole('heading', { name: 'Discovery and review are still needed' })).toBeVisible();
+  await input.fill([
+    'https://boards.greenhouse.io/example',
+    'https://jobs.lever.co/example',
+    'https://example.com/careers',
+    'http://localhost:8787',
+  ].join('\n'));
+  await page.getByRole('button', { name: 'Audit coverage' }).click();
+  await expect(page.getByRole('heading', { name: '2 of 3 valid public URLs match a recognized ATS host' })).toBeVisible();
+  await expect(page.getByText('67%', { exact: true })).toBeVisible();
+  await expect(page.locator('td[data-label="Provider"]', { hasText: 'Greenhouse' })).toBeVisible();
+  await expect(page.getByRole('cell', { name: 'Unknown host' })).toBeVisible();
+  const downloadPromise = page.waitForEvent('download');
+  await page.getByRole('button', { name: 'Download CSV' }).click();
+  const download = await downloadPromise;
+  expect(download.suggestedFilename()).toBe('bd-engine-ats-coverage-audit.csv');
+  await expect(page.getByText(/compatibility signal, not a coverage guarantee/i)).toBeVisible();
 });
 
 test('ATS checker remains usable on mobile without horizontal overflow', async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto('/ats-checker');
 
-  await expect(page.getByRole('heading', { name: 'Check a public career-site URL' })).toBeVisible();
-  await expect(page.getByRole('button', { name: 'Check URL' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Audit ATS coverage for a target list' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Audit coverage' })).toBeVisible();
+  await page.getByLabel('Career-site or job-board URLs').fill([
+    'https://boards.greenhouse.io/example',
+    'https://example.com/careers',
+  ].join('\n'));
+  await page.getByRole('button', { name: 'Audit coverage' }).click();
+  await expect(page.getByRole('heading', { name: '1 of 2 valid public URLs match a recognized ATS host' })).toBeVisible();
+  await expect(page.locator('td[data-label="Provider"]', { hasText: 'Greenhouse' })).toBeVisible();
   const viewport = await page.evaluate(() => ({
     viewportWidth: window.innerWidth,
     documentWidth: document.documentElement.scrollWidth,


### PR DESCRIPTION
## What changed

- expands the public ATS checker from one URL to a 50-URL target-list audit
- reports recognized ATS hosts against an explicit valid-public-URL denominator
- shows per-URL provider and discovery status with a browser-only CSV export
- adds a fully responsive mobile result layout and clearer coverage caveats
- adds unit, browser, download, mobile-overflow, and accessibility coverage

## Why

A single compatibility result did not help users understand portfolio coverage. This release lets staffing teams and job seekers audit the exact list they care about while keeping the claim narrow: host recognition is not a guarantee of complete or fresh role coverage.

## Validation

- `npm test` (231 passed)
- `npm run check`
- `npm run lint`
- `npm run test:browser` (28 Chromium journeys passed)
- `npx playwright test test/browser/discoverability.spec.mjs` (15 Chromium, Firefox, and WebKit tests passed)
- desktop and 390px mobile screenshot inspection
