### PR TITLE
Route coverage campaign to ATS audit

### DIFF
--- a/saas/src/server.js
+++ b/saas/src/server.js
@@ -915,6 +915,12 @@ self.addEventListener('activate', (event) => {
   }
 
   // Static file serving — check cloud public dir first, then app dir
+  if (req.method === 'GET'
+    && pathname === '/'
+    && url.searchParams.get('utm_campaign') === 'coverage_denominator') {
+    return sendRedirect(res, `/ats-checker${url.search}`);
+  }
+
   if (!pathname.startsWith('/api/')) {
     return serveStaticOrSPA(pathname, req, res);
   }
@@ -2897,6 +2903,14 @@ function sendHtml(res, body) {
     'Content-Type': 'text/html; charset=utf-8',
     'Cache-Control': 'no-store',
   }, body);
+}
+
+function sendRedirect(res, location, status = 302) {
+  res.writeHead(status, {
+    'Location': location,
+    'Cache-Control': 'no-store',
+  });
+  res.end();
 }
 
 function sendJavaScript(res, body) {

--- a/saas/test/browser/discoverability.spec.mjs
+++ b/saas/test/browser/discoverability.spec.mjs
@@ -39,6 +39,19 @@ test('clean job-search route publishes focused metadata and campaign attribution
   expect(source).toMatchObject({ source: 'linkedin', campaign: 'role_focus' });
 });
 
+test('coverage-denominator campaign routes to the ATS audit and preserves attribution', async ({ page }) => {
+  await page.goto('/?utm_source=linkedin&utm_medium=organic&utm_campaign=coverage_denominator');
+
+  await expect(page).toHaveURL((url) => (
+    url.pathname === '/ats-checker'
+    && url.searchParams.get('utm_source') === 'linkedin'
+    && url.searchParams.get('utm_medium') === 'organic'
+    && url.searchParams.get('utm_campaign') === 'coverage_denominator'
+  ));
+  await expect(page).toHaveTitle('Free Bulk ATS Coverage Checker | BD Engine');
+  await expect(page.getByRole('heading', { name: 'Audit ATS coverage for a target list' })).toBeVisible();
+});
+
 test('ATS checker audits a target list with an explicit denominator', async ({ page }) => {
   await page.goto('/ats-checker');
   const input = page.getByLabel('Career-site or job-board URLs');


### PR DESCRIPTION
## Summary
- route the existing `coverage_denominator` campaign link to the bulk ATS coverage audit
- preserve all campaign query parameters through the redirect
- add a browser regression test for the live marketing path

## Verification
- `npm test` (231 passed)
- `npm run check`
- `npm run lint`
- `playwright test test/browser/discoverability.spec.mjs --project=chromium` (6 passed)