### PR TITLE
Improve ATS-audit acquisition loop

### DIFF
--- a/docs/bd-engine-organic-campaign-2026-08.md
+++ b/docs/bd-engine-organic-campaign-2026-08.md
@@ -1,0 +1,159 @@
+# BD Engine organic campaign — August/September 2026
+
+## Campaign objective
+
+Turn a narrow, credible free utility into qualified product trials:
+
+1. A staffing leader sees a useful point of view about target-account coverage.
+2. They run the free ATS coverage audit on a real target list.
+3. The result makes recognized sources and unresolved gaps visible.
+4. They continue directly into a BD Engine trial to add target companies, hiring signals, network context, and next actions.
+
+The positioning is **more client conversations with less manual account research**. BD Engine is not presented as another full ATS, a replacement CRM, a LinkedIn automation bot, or a promise of complete job coverage.
+
+## Primary audience
+
+- Staffing agency founders and desk leaders who still assemble target lists manually.
+- Agency recruiters with a business-development responsibility.
+- Small staffing teams that have an ATS or CRM but lack a clear daily account-prioritization queue.
+- Recruiters with a large existing LinkedIn network who are not systematically mapping that network to companies hiring now.
+
+## Message hierarchy
+
+1. **Outcome:** know which target accounts deserve attention today.
+2. **Mechanism:** combine public hiring signals with existing relationship context.
+3. **Proof:** show the denominator, the source, and the unresolved gaps.
+4. **Control:** drafts are assisted and human-reviewed; BD Engine does not auto-send outreach.
+5. **Offer:** free browser-based ATS coverage audit, followed by a 14-day no-card trial.
+
+## Campaign destinations
+
+Use these URLs unchanged so attribution remains comparable:
+
+- LinkedIn launch post → `https://bd-engine-production.up.railway.app/ats-checker?utm_source=linkedin&utm_medium=organic&utm_campaign=coverage_denominator`
+- Playbook post → `https://bd-engine-production.up.railway.app/staffing-bd-playbook?utm_source=linkedin&utm_medium=organic&utm_campaign=staffing_bd_playbook`
+- Workflow/demo post → `https://bd-engine-production.up.railway.app/?utm_source=linkedin&utm_medium=organic&utm_campaign=bd_workflow_demo`
+- Job-seeker crossover post → `https://bd-engine-production.up.railway.app/job-search?utm_source=linkedin&utm_medium=organic&utm_campaign=job_search_focus`
+
+## Four-post LinkedIn sequence
+
+### Post 1 — The denominator problem
+
+Most staffing BD “coverage” numbers are not coverage numbers.
+
+“We monitor 500 companies” sounds useful, but it does not answer the questions that matter:
+
+- How many companies are actually in the target universe?
+- How many have a usable public career source?
+- How many sources are recognized versus unresolved?
+- How many have a current hiring signal worth acting on?
+
+Without a denominator, a large count can hide a large blind spot.
+
+I built a free browser-based ATS coverage audit for this exact first step. Paste up to 50 public career-site URLs and it shows:
+
+- valid URLs audited
+- recognized ATS hosts
+- sources that still need discovery
+- the explicit recognized-host rate
+- a CSV export of the result
+
+The URLs are checked in the browser and are not fetched by the tool. Host recognition is a compatibility signal—not a promise of complete or fresh job coverage.
+
+Run it here:
+https://bd-engine-production.up.railway.app/ats-checker?utm_source=linkedin&utm_medium=organic&utm_campaign=coverage_denominator
+
+### Post 2 — The pre-CRM question
+
+A CRM can tell you what happened.
+
+The harder staffing BD question is what deserves attention today.
+
+For each target account, I want four things visible:
+
+1. Is the company in the defined target universe?
+2. Is there current hiring evidence?
+3. Is the evidence relevant to the desk?
+4. Is there already a warm relationship path?
+
+That produces a much better queue than “work every account” or “message everyone who posted a job.”
+
+The useful output is not more data. It is a short, explainable list of companies, people, and next actions.
+
+I wrote the operating method behind BD Engine here:
+https://bd-engine-production.up.railway.app/staffing-bd-playbook?utm_source=linkedin&utm_medium=organic&utm_campaign=staffing_bd_playbook
+
+### Post 3 — What a hiring signal is not
+
+A job posting is evidence. It is not automatically a good reason to pitch a company.
+
+Before outreach, I would still ask:
+
+- Is the role recent?
+- Is it relevant to the desk?
+- Is the company already over-contacted?
+- Is there a known talent or business leader in the network?
+- Is the source trustworthy and current?
+- What would make the message useful to this recipient?
+
+BD Engine ranks the evidence and prepares a starting draft, but it deliberately keeps the final decision with the recruiter.
+
+No auto-send. No pretending an unresolved source is a confident signal. No score without visible components.
+
+The live synthetic demo shows the workflow:
+https://bd-engine-production.up.railway.app/?utm_source=linkedin&utm_medium=organic&utm_campaign=bd_workflow_demo
+
+### Post 4 — A seven-day pilot
+
+If I were testing a new staffing BD workflow, I would not start with 5,000 companies.
+
+I would start with 25.
+
+Day 1: define the target accounts and why each belongs.
+
+Day 2: collect the best public careers URL for each.
+
+Day 3: separate recognized ATS hosts from sources that still need discovery.
+
+Day 4: map existing LinkedIn connections to the companies.
+
+Day 5: rank current hiring evidence and relationship coverage.
+
+Days 6–7: review the top actions, send only the outreach that makes sense, and record what happened.
+
+The point of the pilot is not message volume. It is whether the workflow produces better conversations with less manual research.
+
+The free audit is a useful place to begin:
+https://bd-engine-production.up.railway.app/ats-checker?utm_source=linkedin&utm_medium=organic&utm_campaign=coverage_denominator
+
+## Reply prompts for comments
+
+Use these only when they answer the actual comment; do not paste them indiscriminately.
+
+- “That distinction is exactly why I keep recognized-host rate separate from actionable coverage. One tells you the source pattern; the other tells you whether there is a usable current signal.”
+- “I see BD Engine as the prioritization layer before the CRM record: what changed, why it matters, who may already know the account, and what the next action is.”
+- “The current workflow creates assisted drafts, but the recruiter reviews the facts, tone, recipient, timing, and channel before anything is sent.”
+- “Unresolved sources remain visible by design. Hiding them would make the coverage number look better while making the workflow less trustworthy.”
+
+## Measurement plan
+
+Review the funnel weekly by campaign, not by total traffic alone:
+
+| Stage | Event or evidence | Diagnostic question |
+| --- | --- | --- |
+| Reach | LinkedIn impressions and profile views | Did the idea earn attention from the intended audience? |
+| Visit | Campaign-attributed page view | Did the post create enough curiosity to visit? |
+| Utility use | `tool_used` on `/ats-checker` | Did visitors bring a real target list? |
+| Trial intent | `signup_started` | Did the result make the broader workflow relevant? |
+| Trial creation | `signup_completed` with acquisition source | Did the signup form and offer convert qualified intent? |
+| Activation | Setup complete plus target accounts, contacts, and resolved boards | Did the product reach a useful operating state? |
+| Value | Draft reviewed, next action recorded, or follow-up created | Did the workspace change what the user did next? |
+
+Do not optimize the campaign for raw clicks if utility use, activation, and recorded next actions do not improve. The free audit is the wedge; the activated workflow is the product.
+
+## Publishing cadence
+
+- Publish one primary post every 5–7 days.
+- Reply to substantive comments the same day when possible.
+- Repost only when there is a new product fact, example, or lesson—not merely to repeat the link.
+- After four posts, keep the two themes with the strongest utility-use and activation rates and retire the rest.

--- a/saas/public/ats-checker.css
+++ b/saas/public/ats-checker.css
@@ -425,6 +425,250 @@ footer {
   font-size: 13px;
 }
 
+/* Staffing BD playbook */
+
+.playbook-main {
+  padding-block: 64px 96px;
+}
+
+.playbook-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(300px, 0.65fr);
+  gap: 48px;
+  align-items: center;
+  padding-bottom: 64px;
+  border-bottom: 1px solid #1c2940;
+}
+
+.playbook-hero h1 {
+  max-width: 780px;
+}
+
+.playbook-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 14px;
+  margin-top: 26px;
+}
+
+.playbook-actions a {
+  display: inline-flex;
+  min-height: 44px;
+  align-items: center;
+  padding: 0 16px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  color: #dce9ff;
+  font-size: 14px;
+  font-weight: 750;
+  text-decoration: none;
+}
+
+.playbook-actions a:hover,
+.playbook-actions a:focus-visible {
+  border-color: var(--accent);
+  background: #142b50;
+}
+
+.playbook-actions .playbook-primary {
+  border-color: var(--accent);
+  background: var(--accent-strong);
+  color: #ffffff;
+}
+
+.playbook-scorecard {
+  padding: 24px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background:
+    radial-gradient(circle at top right, rgba(63, 131, 248, 0.16), transparent 42%),
+    var(--surface);
+}
+
+.playbook-scorecard ol {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.playbook-scorecard li {
+  display: grid;
+  gap: 3px;
+  padding: 12px 14px;
+  border: 1px solid rgba(169, 180, 200, 0.14);
+  border-radius: 7px;
+  background: rgba(8, 13, 24, 0.54);
+}
+
+.playbook-scorecard strong {
+  color: #ffffff;
+  font-size: 14px;
+}
+
+.playbook-scorecard span {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.playbook-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 220px;
+  gap: 64px;
+  align-items: start;
+  padding-top: 64px;
+}
+
+.playbook-content {
+  min-width: 0;
+}
+
+.playbook-content > section + section {
+  margin-top: 72px;
+}
+
+.playbook-content h2 {
+  margin-bottom: 16px;
+  color: #ffffff;
+  font-size: clamp(26px, 4vw, 38px);
+  line-height: 1.15;
+}
+
+.playbook-content h3 {
+  color: #ffffff;
+  font-size: 17px;
+}
+
+.playbook-content p,
+.playbook-content li {
+  color: var(--muted);
+  line-height: 1.75;
+}
+
+.playbook-content p + p {
+  margin-top: 16px;
+}
+
+.playbook-method-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  margin-top: 26px;
+}
+
+.playbook-method-grid > div {
+  min-height: 224px;
+  padding: 22px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.playbook-method-grid span {
+  display: inline-flex;
+  margin-bottom: 18px;
+  color: #83b4ff;
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.playbook-method-grid h3 {
+  margin-bottom: 8px;
+}
+
+.playbook-table-wrap {
+  width: 100%;
+  max-width: 100%;
+  margin-top: 24px;
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.playbook-table-wrap td:first-child {
+  color: #ffffff;
+}
+
+.playbook-callout {
+  margin-top: 20px;
+  padding: 18px 20px;
+  border-left: 3px solid var(--warning);
+  border-radius: 0 7px 7px 0;
+  background: rgba(251, 191, 36, 0.08);
+}
+
+.playbook-callout strong {
+  color: #ffffff;
+}
+
+.playbook-pilot,
+.playbook-guardrails {
+  display: grid;
+  gap: 12px;
+  margin: 22px 0 0;
+  padding-left: 24px;
+}
+
+.playbook-pilot strong,
+.playbook-guardrails strong {
+  color: #ffffff;
+}
+
+.playbook-faq details {
+  padding: 16px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.playbook-faq summary {
+  color: #ffffff;
+  font-weight: 750;
+  cursor: pointer;
+}
+
+.playbook-faq details p {
+  margin: 10px 0 0;
+}
+
+.playbook-final-cta {
+  padding: 34px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background:
+    radial-gradient(circle at top left, rgba(52, 211, 153, 0.12), transparent 34%),
+    var(--surface);
+}
+
+.playbook-toc {
+  position: sticky;
+  top: 24px;
+  display: grid;
+  gap: 10px;
+  padding: 20px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.playbook-toc strong {
+  margin-bottom: 5px;
+  color: #ffffff;
+  font-size: 13px;
+}
+
+.playbook-toc a {
+  color: var(--muted);
+  font-size: 13px;
+  text-decoration: none;
+}
+
+.playbook-toc a:hover,
+.playbook-toc a:focus-visible {
+  color: #ffffff;
+}
+
 @media (max-width: 760px) {
   .site-header,
   main,
@@ -452,6 +696,51 @@ footer {
   .checker-layout {
     grid-template-columns: 1fr;
     gap: 34px;
+  }
+
+  .playbook-main {
+    padding-block: 44px 64px;
+  }
+
+  .playbook-hero,
+  .playbook-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .playbook-hero {
+    gap: 30px;
+    padding-bottom: 48px;
+  }
+
+  .playbook-layout {
+    gap: 40px;
+    padding-top: 48px;
+  }
+
+  .playbook-toc {
+    position: static;
+    order: -1;
+  }
+
+  .playbook-method-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .playbook-method-grid > div {
+    min-height: 0;
+  }
+
+  .playbook-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .playbook-actions a {
+    justify-content: center;
+  }
+
+  .playbook-final-cta {
+    padding: 26px 20px;
   }
 
   .checker-panel {

--- a/saas/public/ats-checker.html
+++ b/saas/public/ats-checker.html
@@ -43,6 +43,7 @@
       <span>BD Engine</span>
     </a>
     <nav aria-label="Primary navigation">
+      <a href="/staffing-bd-playbook?utm_source=ats-checker&utm_medium=navigation&utm_campaign=checker_playbook">BD playbook</a>
       <a href="/job-search">Job search</a>
       <a class="header-cta" href="/?utm_source=ats-checker&utm_medium=tool&utm_campaign=checker_navigation">Staffing workflow</a>
     </nav>
@@ -100,6 +101,7 @@
           <li>Employers can change, hide, or customize public career pages.</li>
           <li>Ordinary company careers pages may still need discovery and review.</li>
         </ul>
+        <p><a href="/staffing-bd-playbook?utm_source=ats-checker&utm_medium=tool&utm_campaign=checker_playbook">See how to turn this denominator into a staffing BD workflow.</a></p>
       </aside>
     </div>
   </main>

--- a/saas/public/ats-checker.js
+++ b/saas/public/ats-checker.js
@@ -12,6 +12,8 @@ const PROVIDERS = [
   ['Rippling', ['ats.rippling.com']],
 ];
 
+const PENDING_AUDIT_SUMMARY_KEY = 'bd_pending_audit_summary';
+
 export function classifyCareerUrl(value) {
   const raw = String(value || '').trim();
   if (!raw) return { status: 'invalid', submittedUrl: raw, title: 'Enter a public URL', tone: 'error' };
@@ -106,6 +108,43 @@ export function buildCoverageCsv(audit) {
     ]);
   }
   return rows.map((row) => row.map(csvCell).join(',')).join('\r\n');
+}
+
+export function buildShareSummary(audit) {
+  const validCount = Number(audit?.validCount || 0);
+  const recognizedCount = Number(audit?.recognizedCount || 0);
+  const reviewCount = Number(audit?.reviewCount || 0);
+  const recognitionRate = Number(audit?.recognitionRate || 0);
+  if (!validCount) {
+    return 'ATS coverage audit: no valid public career-site URLs were available to score.';
+  }
+  const reviewLabel = reviewCount === 1 ? '1 URL still needs' : `${reviewCount} URLs still need`;
+  return `ATS coverage audit: ${recognizedCount} of ${validCount} valid public URLs (${recognitionRate}%) use a recognized ATS host. ${reviewLabel} discovery. Host recognition is a compatibility signal, not a guarantee of complete or fresh job coverage.`;
+}
+
+function storePendingAuditSummary(audit) {
+  if (typeof sessionStorage === 'undefined') return;
+  try {
+    if (!audit?.validCount) {
+      sessionStorage.removeItem(PENDING_AUDIT_SUMMARY_KEY);
+      return;
+    }
+    sessionStorage.setItem(PENDING_AUDIT_SUMMARY_KEY, JSON.stringify({
+      validCount: Number(audit.validCount || 0),
+      recognizedCount: Number(audit.recognizedCount || 0),
+      reviewCount: Number(audit.reviewCount || 0),
+      recognitionRate: Number(audit.recognitionRate || 0),
+      createdAt: Date.now(),
+    }));
+  } catch {
+    // The audit remains usable when browser storage is disabled.
+  }
+}
+
+async function copyAuditSummary(audit) {
+  const summary = buildShareSummary(audit);
+  if (!navigator.clipboard?.writeText) throw new Error('Clipboard access is unavailable.');
+  await navigator.clipboard.writeText(summary);
 }
 
 function isPublicHostname(hostname) {
@@ -246,21 +285,34 @@ function renderResult(audit) {
   note.hidden = notes.length === 0;
   renderAuditRows(audit);
   actions.replaceChildren();
+  storePendingAuditSummary(audit);
 
   if (hasValidUrls) {
+    const copyButton = document.createElement('button');
+    copyButton.type = 'button';
+    copyButton.className = 'copy-action';
+    copyButton.textContent = 'Copy summary';
+    copyButton.addEventListener('click', async () => {
+      try {
+        await copyAuditSummary(audit);
+        copyButton.textContent = 'Summary copied';
+      } catch {
+        copyButton.textContent = 'Copy unavailable';
+      }
+    });
     const exportButton = document.createElement('button');
     exportButton.type = 'button';
     exportButton.className = 'export-action';
     exportButton.textContent = 'Download CSV';
     exportButton.addEventListener('click', () => downloadCoverageCsv(audit));
     const staffingLink = document.createElement('a');
-    staffingLink.href = '/?utm_source=ats-checker&utm_medium=tool&utm_campaign=coverage_audit_result';
+    staffingLink.href = '/?signup=1&persona=bd&utm_source=ats-checker&utm_medium=tool&utm_campaign=coverage_audit_result';
     staffingLink.className = 'primary-workflow';
-    staffingLink.textContent = 'Prioritize target companies';
+    staffingLink.textContent = 'Build a workflow from this audit';
     const jobSearchLink = document.createElement('a');
-    jobSearchLink.href = '/job-search?utm_source=ats-checker&utm_medium=tool&utm_campaign=coverage_audit_result';
-    jobSearchLink.textContent = 'Find relevant roles';
-    actions.append(exportButton, staffingLink, jobSearchLink);
+    jobSearchLink.href = '/job-search?signup=1&utm_source=ats-checker&utm_medium=tool&utm_campaign=coverage_audit_result';
+    jobSearchLink.textContent = 'Use it for a job search';
+    actions.append(copyButton, exportButton, staffingLink, jobSearchLink);
   }
 }
 

--- a/saas/public/cloud.css
+++ b/saas/public/cloud.css
@@ -164,6 +164,14 @@ a:hover { text-decoration: underline; }
   background: var(--accent-soft);
 }
 
+.nav-tool-link {
+  text-decoration: none;
+}
+
+.nav-tool-link:hover {
+  text-decoration: none;
+}
+
 /* ── Buttons ── */
 
 .btn {
@@ -575,6 +583,91 @@ a:hover { text-decoration: underline; }
   line-height: 1.6;
 }
 
+/* ── Workflow proof ── */
+
+.workflow-proof {
+  width: min(100% - 48px, 1120px);
+  margin: 0 auto;
+  padding: 64px;
+  display: grid;
+  grid-template-columns: minmax(0, 0.9fr) minmax(420px, 1.1fr);
+  gap: 54px;
+  align-items: center;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-xl);
+  background:
+    radial-gradient(circle at 10% 10%, rgba(99, 102, 241, 0.14), transparent 34%),
+    linear-gradient(135deg, rgba(17, 24, 39, 0.96), rgba(10, 22, 40, 0.92));
+  box-shadow: var(--shadow-md);
+}
+
+.workflow-proof-copy h2 {
+  margin-bottom: 16px;
+  font-size: clamp(30px, 4vw, 42px);
+  line-height: 1.08;
+  letter-spacing: -0.8px;
+}
+
+.workflow-proof-copy > p,
+.workflow-proof-steps p {
+  color: var(--text-secondary);
+  line-height: 1.65;
+}
+
+.workflow-proof-actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-top: 26px;
+}
+
+.workflow-proof-link {
+  font-size: 14px;
+  font-weight: 700;
+  text-underline-offset: 3px;
+}
+
+.workflow-proof-steps {
+  display: grid;
+  gap: 14px;
+  padding: 0;
+  list-style: none;
+}
+
+.workflow-proof-steps li {
+  display: grid;
+  grid-template-columns: 38px minmax(0, 1fr);
+  gap: 14px;
+  padding: 18px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: rgba(15, 23, 42, 0.72);
+}
+
+.workflow-step-number {
+  display: inline-flex;
+  width: 34px;
+  height: 34px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: var(--accent-soft);
+  color: var(--accent-hover);
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.workflow-proof-steps strong {
+  display: block;
+  margin-bottom: 4px;
+  font-size: 16px;
+}
+
+.workflow-proof-steps p {
+  font-size: 13px;
+}
+
 /* ── Referrals ── */
 
 .referral-program {
@@ -973,6 +1066,35 @@ a:hover { text-decoration: underline; }
   padding: 10px 14px;
   border-radius: var(--radius-sm);
   margin-bottom: 20px;
+}
+
+.auth-audit-intent {
+  display: grid;
+  gap: 5px;
+  margin-bottom: 20px;
+  padding: 14px 16px;
+  border: 1px solid rgba(52, 211, 153, 0.28);
+  border-radius: var(--radius-md);
+  background: rgba(16, 185, 129, 0.08);
+}
+
+.auth-audit-intent > span {
+  color: var(--green);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.auth-audit-intent strong {
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.auth-audit-intent p {
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.5;
 }
 
 .auth-success {
@@ -1802,6 +1924,7 @@ a:hover { text-decoration: underline; }
   .hero-visual { height: 360px; }
 
   .features-grid { grid-template-columns: repeat(2, 1fr); }
+  .workflow-proof { grid-template-columns: 1fr; padding: 44px; }
   .referral-program { grid-template-columns: 1fr; }
   .referral-flow { grid-template-columns: 1fr; }
   .pricing-grid { grid-template-columns: 1fr; max-width: 400px; margin: 0 auto; }
@@ -1844,6 +1967,15 @@ a:hover { text-decoration: underline; }
   .features-grid { grid-template-columns: 1fr; }
   .section-title { font-size: 26px; }
 
+  .workflow-proof {
+    width: calc(100% - 32px);
+    padding: 32px 20px;
+    gap: 32px;
+  }
+  .workflow-proof-copy h2 { font-size: 28px; }
+  .workflow-proof-actions { align-items: stretch; flex-direction: column; }
+  .workflow-proof-actions .btn { width: 100%; }
+
   .referral-program { padding: 56px 16px; }
   .referral-copy h2 { font-size: 28px; }
 
@@ -1854,6 +1986,7 @@ a:hover { text-decoration: underline; }
   .landing-nav-brand .brand-text { font-size: 16px; white-space: nowrap; }
   .landing-nav-actions { gap: 6px; margin-left: auto; }
   .landing-nav-actions [data-trust-page] { display: none; }
+  .landing-nav-actions .nav-tool-link { display: none; }
   .landing-nav-actions .nav-link { padding: 8px; font-size: 13px; }
   .landing-nav-actions .btn { padding: 9px 12px; font-size: 13px; }
   .auth-card { padding: 28px 20px; }

--- a/saas/public/index.html
+++ b/saas/public/index.html
@@ -91,6 +91,7 @@
       persona: 'bd',
       signupPersona: getInitialSignupPersona(),
       acquisition: getInitialAcquisition(),
+      auditSummary: getInitialAuditSummary(),
     };
 
     function getInitialReferralCode() {
@@ -115,6 +116,31 @@
     function getInitialSignupPersona() {
       const requestedPersona = new URLSearchParams(window.location.search).get('persona');
       return window.location.pathname === '/job-search' || requestedPersona === 'jobseeker' ? 'jobseeker' : 'bd';
+    }
+
+    function getInitialAuditSummary() {
+      try {
+        const summary = JSON.parse(sessionStorage.getItem('bd_pending_audit_summary') || 'null');
+        const age = Date.now() - Number(summary?.createdAt || 0);
+        const validCount = Number(summary?.validCount || 0);
+        const recognizedCount = Number(summary?.recognizedCount || 0);
+        const reviewCount = Number(summary?.reviewCount || 0);
+        const recognitionRate = Number(summary?.recognitionRate || 0);
+        if (!validCount || age < 0 || age > 24 * 60 * 60 * 1000) {
+          sessionStorage.removeItem('bd_pending_audit_summary');
+          return null;
+        }
+        return { validCount, recognizedCount, reviewCount, recognitionRate };
+      } catch {
+        return null;
+      }
+    }
+
+    function getRequestedUnauthenticatedView() {
+      if (state.resetToken) return 'reset';
+      const params = new URLSearchParams(window.location.search);
+      if (params.get('signup') === '1') return 'signup';
+      return params.get('login') === '1' ? 'login' : 'landing';
     }
 
     function getInitialAcquisition() {
@@ -269,15 +295,14 @@
           } else {
             state.view = 'app';
           }
-        } else if (state.resetToken) {
-          state.view = 'reset';
         } else {
-          state.view = new URLSearchParams(window.location.search).get('login') === '1' ? 'login' : 'landing';
+          state.view = getRequestedUnauthenticatedView();
         }
       } catch {
-        state.view = state.resetToken
-          ? 'reset'
-          : (new URLSearchParams(window.location.search).get('login') === '1' ? 'login' : 'landing');
+        state.view = getRequestedUnauthenticatedView();
+      }
+      if (!state.user && state.view === 'signup' && new URLSearchParams(window.location.search).get('signup') === '1') {
+        trackAcquisitionEvent('signup_started').catch(() => {});
       }
       render();
     }
@@ -363,6 +388,8 @@
         if (data.verificationEmailSent) {
           state.verificationMessage = `A verification link was sent to ${data.user?.email || email}.`;
         }
+        try { sessionStorage.removeItem('bd_pending_audit_summary'); } catch {}
+        state.auditSummary = null;
         state.view = 'app';
         state.error = '';
       } catch (err) {
@@ -677,6 +704,25 @@
         ['ATS', 'ATS Discovery', 'Automatically discover compatible public job boards, with manual URL entry and a review queue for sites that need help.'],
         ['TA', 'Workflow Analytics', 'Track outreach velocity, pipeline coverage, follow-up queues, and data quality so the next action stays clear.'],
       ];
+      const workflowProof = isJobSeekerLanding ? {
+        kicker: 'One focused loop',
+        title: 'From a broad search to the next useful action',
+        intro: 'Define what fits, monitor the companies that matter, then use role evidence and network context to choose where to spend today\'s effort.',
+        steps: [
+          ['Set the focus', 'Choose role families, locations, and keywords so irrelevant openings stop crowding the queue.'],
+          ['Rank the evidence', 'Compare relevant public roles, target-company activity, and possible warm contacts in one view.'],
+          ['Take the next step', 'Review a grounded introduction draft, apply, research, or follow up without automating the human decision.'],
+        ],
+      } : {
+        kicker: 'The operating loop',
+        title: 'From a target list to the next client conversation',
+        intro: 'BD Engine turns scattered account research into a repeatable workflow: define the universe, verify hiring evidence, map the warmest path, and decide the next action.',
+        steps: [
+          ['Define the universe', 'Import the accounts and LinkedIn connections you already care about, then add the public career sites worth tracking.'],
+          ['Rank current demand', 'Use transparent hiring velocity, role activity, and relationship coverage to see which accounts deserve attention now.'],
+          ['Prepare the conversation', 'Start from a context-aware draft, review it yourself, and record the next step. BD Engine does not auto-send outreach.'],
+        ],
+      };
       root.innerHTML = `
         <div class="landing">
           <nav class="landing-nav">
@@ -687,6 +733,7 @@
               <span class="brand-text">BD Engine <span class="brand-cloud">Cloud</span></span>
             </div>
             <div class="landing-nav-actions">
+              ${isJobSeekerLanding ? '' : '<a class="nav-link nav-tool-link" href="/ats-checker?utm_source=homepage&utm_medium=navigation&utm_campaign=free_ats_audit">Free ATS audit</a>'}
               <button class="nav-link" data-trust-page="trust">Trust</button>
               <button class="nav-link" data-trust-page="status">Status</button>
               <button class="nav-link" id="nav-login">Log in</button>
@@ -741,6 +788,27 @@
                 </div>
               </div>
             </div>
+          </section>
+
+          <section class="workflow-proof" id="how-it-works" aria-labelledby="workflow-proof-title">
+            <div class="workflow-proof-copy">
+              <span class="section-kicker">${workflowProof.kicker}</span>
+              <h2 id="workflow-proof-title">${workflowProof.title}</h2>
+              <p>${workflowProof.intro}</p>
+              <div class="workflow-proof-actions">
+                <a class="btn btn-ghost" href="/ats-checker?utm_source=homepage&utm_medium=workflow&utm_campaign=free_ats_audit">Audit a target list free</a>
+                ${isJobSeekerLanding
+                  ? '<button class="link-btn" data-jobseeker-signup>Start a focused search</button>'
+                  : '<a class="workflow-proof-link" href="/staffing-bd-playbook?utm_source=homepage&utm_medium=workflow&utm_campaign=staffing_bd_playbook">Read the staffing BD playbook</a>'}
+              </div>
+            </div>
+            <ol class="workflow-proof-steps">
+              ${workflowProof.steps.map(([title, description], index) => `
+                <li>
+                  <span class="workflow-step-number">${index + 1}</span>
+                  <div><strong>${title}</strong><p>${description}</p></div>
+                </li>`).join('')}
+            </ol>
           </section>
 
           <section class="features" id="features">
@@ -837,6 +905,8 @@
               <span class="brand-text">BD Engine <span class="brand-cloud">Cloud</span></span>
             </div>
             <div class="landing-footer-links">
+              <a class="link-btn" href="/ats-checker?utm_source=homepage&utm_medium=footer&utm_campaign=free_ats_audit">Free ATS audit</a>
+              <a class="link-btn" href="/staffing-bd-playbook?utm_source=homepage&utm_medium=footer&utm_campaign=staffing_bd_playbook">Staffing BD playbook</a>
               <button class="link-btn" data-trust-page="trust">Trust</button>
               <button class="link-btn" data-trust-page="privacy">Privacy</button>
               <button class="link-btn" data-trust-page="terms">Terms</button>
@@ -1123,6 +1193,10 @@
     }
 
     function renderSignup() {
+      const auditSummary = state.auditSummary;
+      const auditReviewCopy = auditSummary
+        ? `${auditSummary.reviewCount} ${auditSummary.reviewCount === 1 ? 'site still needs' : 'sites still need'} discovery.`
+        : '';
       root.innerHTML = `
         <div class="auth-page">
           <div class="auth-card">
@@ -1133,6 +1207,12 @@
               <h2>Create your account</h2>
               <p>Start your 14-day free trial — no credit card required</p>
             </div>
+            ${auditSummary ? `
+              <div class="auth-audit-intent" role="status">
+                <span>Coverage audit complete</span>
+                <strong>${auditSummary.recognizedCount} of ${auditSummary.validCount} valid career sites are on recognized ATS hosts.</strong>
+                <p>${auditReviewCopy} Create the workspace, then add the companies you want BD Engine to monitor and prioritize.</p>
+              </div>` : ''}
             ${state.referralCode ? `<div class="auth-error" role="status" style="background: rgba(34, 197, 94, .08); border-color: rgba(34, 197, 94, .28); color: #166534;">Referral code ${escapeHtml(state.referralCode)} will be applied when you subscribe.</div>` : ''}
             ${state.error ? `<div class="auth-error" role="alert">${escapeHtml(state.error)}</div>` : ''}
             <form id="signup-form" class="auth-form">

--- a/saas/public/sitemap.xml
+++ b/saas/public/sitemap.xml
@@ -2,19 +2,25 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://bd-engine-production.up.railway.app/</loc>
-    <lastmod>2026-08-01</lastmod>
+    <lastmod>2026-08-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://bd-engine-production.up.railway.app/job-search</loc>
-    <lastmod>2026-08-01</lastmod>
+    <lastmod>2026-08-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://bd-engine-production.up.railway.app/ats-checker</loc>
-    <lastmod>2026-08-01</lastmod>
+    <lastmod>2026-08-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://bd-engine-production.up.railway.app/staffing-bd-playbook</loc>
+    <lastmod>2026-08-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/saas/public/staffing-bd-playbook.html
+++ b/saas/public/staffing-bd-playbook.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="A practical staffing business-development playbook for defining target accounts, measuring ATS coverage, ranking live hiring signals, mapping warm contacts, and choosing the next action.">
+  <meta name="robots" content="index, follow, max-image-preview:large">
+  <link rel="canonical" href="https://bd-engine-production.up.railway.app/staffing-bd-playbook">
+  <meta property="og:type" content="article">
+  <meta property="og:site_name" content="BD Engine Cloud">
+  <meta property="og:title" content="Staffing Business Development Playbook | BD Engine">
+  <meta property="og:description" content="Turn a staffing target list into a measurable hiring-signal workflow without replacing human judgment.">
+  <meta property="og:url" content="https://bd-engine-production.up.railway.app/staffing-bd-playbook">
+  <meta property="og:image" content="https://bd-engine-production.up.railway.app/bd-engine-logo.png">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="Staffing Business Development Playbook | BD Engine">
+  <meta name="twitter:description" content="Define the target universe, verify hiring evidence, map warm paths, and choose the next action.">
+  <meta name="twitter:image" content="https://bd-engine-production.up.railway.app/bd-engine-logo.png">
+  <meta name="theme-color" content="#080d18">
+  <title>Staffing Business Development Playbook | BD Engine</title>
+  <link rel="stylesheet" href="/ats-checker.css">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "Article",
+        "headline": "A hiring-signal playbook for staffing business development",
+        "description": "A practical operating method for defining target accounts, measuring ATS coverage, ranking live hiring signals, mapping warm contacts, and choosing the next action.",
+        "datePublished": "2026-08-15",
+        "dateModified": "2026-08-15",
+        "author": { "@type": "Organization", "name": "BD Engine" },
+        "publisher": { "@type": "Organization", "name": "BD Engine", "logo": { "@type": "ImageObject", "url": "https://bd-engine-production.up.railway.app/bd-engine-logo.png" } },
+        "mainEntityOfPage": "https://bd-engine-production.up.railway.app/staffing-bd-playbook"
+      },
+      {
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "Does a recognized ATS host mean every job is covered?",
+            "acceptedAnswer": { "@type": "Answer", "text": "No. Host recognition is a compatibility signal. It does not confirm that every role is available, current, relevant, or successfully imported." }
+          },
+          {
+            "@type": "Question",
+            "name": "Does this replace a staffing CRM?",
+            "acceptedAnswer": { "@type": "Answer", "text": "No. The workflow helps decide which accounts and contacts deserve attention now. A CRM can remain the system of record for longer-term client activity." }
+          },
+          {
+            "@type": "Question",
+            "name": "Does BD Engine send outreach automatically?",
+            "acceptedAnswer": { "@type": "Answer", "text": "No. BD Engine creates assisted drafts and next-action context for the user to review. The user decides whether, when, and how to send outreach." }
+          }
+        ]
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
+  <header class="site-header">
+    <a class="brand" href="/" aria-label="BD Engine home">
+      <img src="/bd-engine-logo.png" alt="" width="34" height="34">
+      <span>BD Engine</span>
+    </a>
+    <nav aria-label="Primary navigation">
+      <a href="/ats-checker?utm_source=playbook&utm_medium=navigation&utm_campaign=staffing_bd_playbook">Free ATS audit</a>
+      <a class="header-cta" href="/?signup=1&persona=bd&utm_source=playbook&utm_medium=organic&utm_campaign=staffing_bd_playbook">Start free trial</a>
+    </nav>
+  </header>
+
+  <main class="playbook-main">
+    <article>
+      <header class="playbook-hero">
+        <div class="playbook-hero-copy">
+          <p class="eyebrow">Staffing BD operating guide</p>
+          <h1>A hiring-signal playbook for staffing business development</h1>
+          <p class="lede">Build a defined target universe, measure what you can actually monitor, combine hiring evidence with relationship context, and turn the result into a short daily action queue.</p>
+          <div class="playbook-actions">
+            <a class="playbook-primary" href="/ats-checker?utm_source=playbook&utm_medium=article&utm_campaign=staffing_bd_playbook">Audit a target list free</a>
+            <a href="/?utm_source=playbook&utm_medium=article&utm_campaign=staffing_bd_playbook">See the BD Engine workflow</a>
+          </div>
+        </div>
+        <aside class="playbook-scorecard" aria-label="The four-part operating loop">
+          <p class="eyebrow">The operating loop</p>
+          <ol>
+            <li><strong>Define</strong><span>Target accounts and usable career sources</span></li>
+            <li><strong>Verify</strong><span>Current hiring evidence and visible gaps</span></li>
+            <li><strong>Rank</strong><span>Demand, relevance, and relationship coverage</span></li>
+            <li><strong>Act</strong><span>Human-reviewed outreach and the next step</span></li>
+          </ol>
+        </aside>
+      </header>
+
+      <div class="playbook-layout">
+        <div class="playbook-content">
+          <section id="operating-question">
+            <p class="eyebrow">The operating question</p>
+            <h2>Which accounts deserve attention today—and why?</h2>
+            <p>A database can tell you what exists. A useful business-development queue must tell you what changed, whether the evidence is relevant, where a relationship may already exist, and what the next action should be.</p>
+            <p>Start with a bounded target list. Without that denominator, “coverage” becomes an impressive-looking count that cannot tell you what is missing. With a defined universe, every gap can become a concrete research or follow-up task.</p>
+          </section>
+
+          <section id="workflow">
+            <p class="eyebrow">The method</p>
+            <h2>A four-stage staffing BD workflow</h2>
+            <div class="playbook-method-grid">
+              <div><span>01</span><h3>Define the target universe</h3><p>Choose accounts that fit the desk, geography, role family, or client hypothesis. Record a company identity and the best known public careers URL.</p></div>
+              <div><span>02</span><h3>Measure source coverage</h3><p>Separate recognized ATS hosts, ordinary careers pages that need discovery, invalid entries, and unresolved companies. Keep every denominator explicit.</p></div>
+              <div><span>03</span><h3>Rank current demand</h3><p>Compare recent role activity, hiring velocity, role relevance, and network coverage. A strong signal is useful because its components remain visible.</p></div>
+              <div><span>04</span><h3>Review the next action</h3><p>Use the evidence to research, request an introduction, prepare an outreach draft, or schedule a follow-up. Keep a person responsible for the final decision.</p></div>
+            </div>
+          </section>
+
+          <section id="metrics">
+            <p class="eyebrow">Measurement</p>
+            <h2>Use coverage metrics that lead to action</h2>
+            <div class="playbook-table-wrap">
+              <table>
+                <caption class="sr-only">Staffing business-development coverage metrics</caption>
+                <thead><tr><th scope="col">Metric</th><th scope="col">Denominator</th><th scope="col">When it is weak</th></tr></thead>
+                <tbody>
+                  <tr><td data-label="Metric"><strong>Source coverage</strong></td><td data-label="Denominator">Target accounts with a usable public careers URL ÷ all target accounts</td><td data-label="When it is weak">Resolve company identity and careers-page gaps.</td></tr>
+                  <tr><td data-label="Metric"><strong>Recognized-host rate</strong></td><td data-label="Denominator">Recognized ATS hosts ÷ valid public URLs audited</td><td data-label="When it is weak">Review ordinary careers pages and unsupported providers.</td></tr>
+                  <tr><td data-label="Metric"><strong>Actionable coverage</strong></td><td data-label="Denominator">Target accounts with a current, usable hiring signal ÷ all target accounts</td><td data-label="When it is weak">Refresh sources, narrow the target list, or improve role relevance.</td></tr>
+                  <tr><td data-label="Metric"><strong>Warm-path coverage</strong></td><td data-label="Denominator">Target accounts with a relevant known contact ÷ all target accounts</td><td data-label="When it is weak">Map existing connections before defaulting to cold outreach.</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p class="playbook-callout"><strong>Important:</strong> a recognized ATS host is not the same as complete job coverage. It identifies a compatible source pattern; it does not prove role count, freshness, relevance, or successful retrieval.</p>
+          </section>
+
+          <section id="pilot">
+            <p class="eyebrow">Seven-day pilot</p>
+            <h2>Prove the workflow on a small target list</h2>
+            <ol class="playbook-pilot">
+              <li><strong>Day 1:</strong> select 25 target accounts with a clear fit hypothesis.</li>
+              <li><strong>Day 2:</strong> collect or audit their public career-site URLs.</li>
+              <li><strong>Day 3:</strong> resolve the highest-value source gaps instead of hiding them.</li>
+              <li><strong>Day 4:</strong> import your existing network and identify possible warm paths.</li>
+              <li><strong>Day 5:</strong> rank accounts using current role evidence and relationship context.</li>
+              <li><strong>Days 6–7:</strong> review the top actions, send only the outreach you approve, and record what happened.</li>
+            </ol>
+          </section>
+
+          <section id="guardrails">
+            <p class="eyebrow">Guardrails</p>
+            <h2>Keep judgment in the workflow</h2>
+            <ul class="playbook-guardrails">
+              <li>Use only company, contact, and public job data you have the right to process.</li>
+              <li>Show unresolved sources and missing evidence instead of converting uncertainty into a confident score.</li>
+              <li>Treat assisted copy as a first draft. Review the facts, tone, recipient, timing, and channel yourself.</li>
+              <li>Measure conversations and useful next steps—not message volume alone.</li>
+            </ul>
+          </section>
+
+          <section id="faq" class="playbook-faq">
+            <p class="eyebrow">FAQ</p>
+            <h2>Common questions</h2>
+            <details><summary>Does a recognized ATS host mean every job is covered?</summary><p>No. It is a compatibility signal, not confirmation that every role is available, current, relevant, or successfully imported.</p></details>
+            <details><summary>Does this replace a staffing CRM?</summary><p>No. This workflow helps decide which accounts and contacts deserve attention now. A CRM can remain the longer-term system of record.</p></details>
+            <details><summary>Does BD Engine send outreach automatically?</summary><p>No. BD Engine does not auto-send outreach. It creates assisted drafts and next-action context for review. You decide whether, when, and how to send outreach.</p></details>
+          </section>
+
+          <section class="playbook-final-cta" aria-labelledby="playbook-cta-title">
+            <p class="eyebrow">Start with evidence</p>
+            <h2 id="playbook-cta-title">Audit the list you already have</h2>
+            <p>Check up to 50 public career-site URLs in your browser, see the recognized-host denominator, and export the result without creating an account.</p>
+            <div class="playbook-actions">
+              <a class="playbook-primary" href="/ats-checker?utm_source=playbook&utm_medium=cta&utm_campaign=staffing_bd_playbook">Run the free ATS audit</a>
+              <a href="/?signup=1&persona=bd&utm_source=playbook&utm_medium=cta&utm_campaign=staffing_bd_playbook">Start a 14-day trial</a>
+            </div>
+          </section>
+        </div>
+
+        <aside class="playbook-toc" aria-label="Playbook contents">
+          <strong>In this playbook</strong>
+          <a href="#operating-question">The operating question</a>
+          <a href="#workflow">Four-stage workflow</a>
+          <a href="#metrics">Coverage metrics</a>
+          <a href="#pilot">Seven-day pilot</a>
+          <a href="#guardrails">Guardrails</a>
+          <a href="#faq">FAQ</a>
+        </aside>
+      </div>
+    </article>
+  </main>
+
+  <footer>
+    <span>BD Engine Cloud</span>
+    <span>More client conversations with less manual account research.</span>
+  </footer>
+</body>
+</html>

--- a/saas/src/server.js
+++ b/saas/src/server.js
@@ -2659,6 +2659,9 @@ function serveStaticOrSPA(pathname, req, res) {
   if (pathname === '/ats-checker' || pathname === '/ats-checker/') {
     return sendHtml(res, getAtsCheckerHtml(res.bdScriptNonce));
   }
+  if (pathname === '/staffing-bd-playbook' || pathname === '/staffing-bd-playbook/') {
+    return sendHtml(res, getStaffingBdPlaybookHtml(res.bdScriptNonce));
+  }
   if (pathname === '/job-search' || pathname === '/job-search/') {
     return sendHtml(res, getCloudIndexHtml(res.bdScriptNonce, 'jobseeker'));
   }
@@ -2683,6 +2686,7 @@ let cachedAppIndexHtml = null;
 let cachedCloudIndexHtml = null;
 let cachedJobSeekerIndexHtml = null;
 let cachedAtsCheckerHtml = null;
+let cachedStaffingBdPlaybookHtml = null;
 
 function getCloudIndexHtml(scriptNonce, persona = 'bd') {
   if (!cachedCloudIndexHtml) {
@@ -2717,6 +2721,13 @@ function getAtsCheckerHtml(scriptNonce) {
     cachedAtsCheckerHtml = readFileSync(join(publicDir, 'ats-checker.html'), 'utf8');
   }
   return injectScriptNonce(cachedAtsCheckerHtml, scriptNonce);
+}
+
+function getStaffingBdPlaybookHtml(scriptNonce) {
+  if (!cachedStaffingBdPlaybookHtml) {
+    cachedStaffingBdPlaybookHtml = readFileSync(join(publicDir, 'staffing-bd-playbook.html'), 'utf8');
+  }
+  return injectScriptNonce(cachedStaffingBdPlaybookHtml, scriptNonce);
 }
 
 function getAppIndexHtml() {

--- a/saas/test/ats-checker.test.js
+++ b/saas/test/ats-checker.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { buildCoverageAudit, buildCoverageCsv, classifyCareerUrl } from '../public/ats-checker.js';
+import { buildCoverageAudit, buildCoverageCsv, buildShareSummary, classifyCareerUrl } from '../public/ats-checker.js';
 
 test('ATS checker recognizes every provider advertised on the public page', () => {
   const examples = [
@@ -69,4 +69,17 @@ test('ATS coverage CSV exports every audited row and neutralizes formulas', () =
 
   assert.match(csv, /"https:\/\/jobs\.ashbyhq\.com\/example","jobs\.ashbyhq\.com","Recognized","Ashby"/);
   assert.match(csv, /"'=not-a-url","","Invalid",""/);
+});
+
+test('ATS coverage summary preserves the denominator and the coverage caveat', () => {
+  const audit = buildCoverageAudit([
+    'https://boards.greenhouse.io/example',
+    'https://jobs.lever.co/example',
+    'https://example.com/careers',
+  ].join('\n'));
+
+  assert.equal(
+    buildShareSummary(audit),
+    'ATS coverage audit: 2 of 3 valid public URLs (67%) use a recognized ATS host. 1 URL still needs discovery. Host recognition is a compatibility signal, not a guarantee of complete or fresh job coverage.'
+  );
 });

--- a/saas/test/browser/accessibility.spec.mjs
+++ b/saas/test/browser/accessibility.spec.mjs
@@ -36,6 +36,12 @@ test('ATS coverage audit is accessible before and after results render', async (
   await expectNoBlockingViolations(page);
 });
 
+test('staffing BD playbook is accessible', async ({ page }) => {
+  await page.goto('/staffing-bd-playbook');
+  await expect(page.getByRole('heading', { name: 'A hiring-signal playbook for staffing business development' })).toBeVisible();
+  await expectNoBlockingViolations(page);
+});
+
 test('demo workspace has no blocking structural accessibility violations', async ({ page }) => {
   await page.goto('/');
   await page.locator('[data-demo-start]').first().click();

--- a/saas/test/browser/discoverability.spec.mjs
+++ b/saas/test/browser/discoverability.spec.mjs
@@ -39,6 +39,14 @@ test('clean job-search route publishes focused metadata and campaign attribution
   expect(source).toMatchObject({ source: 'linkedin', campaign: 'role_focus' });
 });
 
+test('staffing landing explains the operating loop and exposes the free audit', async ({ page }) => {
+  await page.goto('/');
+
+  await expect(page.getByRole('heading', { name: 'From a target list to the next client conversation' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Audit a target list free' })).toHaveAttribute('href', /\/ats-checker/);
+  await expect(page.getByText('BD Engine does not auto-send outreach.')).toBeVisible();
+});
+
 test('coverage-denominator campaign routes to the ATS audit and preserves attribution', async ({ page }) => {
   await page.goto('/?utm_source=linkedin&utm_medium=organic&utm_campaign=coverage_denominator');
 
@@ -72,6 +80,41 @@ test('ATS checker audits a target list with an explicit denominator', async ({ p
   const download = await downloadPromise;
   expect(download.suggestedFilename()).toBe('bd-engine-ats-coverage-audit.csv');
   await expect(page.getByText(/compatibility signal, not a coverage guarantee/i)).toBeVisible();
+});
+
+test('ATS audit continues directly into a contextual trial form', async ({ page }) => {
+  await page.goto('/ats-checker?utm_source=linkedin&utm_campaign=coverage_denominator');
+  await page.getByLabel('Career-site or job-board URLs').fill([
+    'https://boards.greenhouse.io/example',
+    'https://jobs.lever.co/example',
+    'https://example.com/careers',
+  ].join('\n'));
+  await page.getByRole('button', { name: 'Audit coverage' }).click();
+
+  await page.getByRole('link', { name: 'Build a workflow from this audit' }).click();
+  await expect(page).toHaveURL((url) => url.pathname === '/' && url.searchParams.get('signup') === '1');
+  await expect(page.getByRole('heading', { name: 'Create your account' })).toBeVisible();
+  await expect(page.getByText('Coverage audit complete')).toBeVisible();
+  await expect(page.getByText('2 of 3 valid career sites are on recognized ATS hosts.')).toBeVisible();
+  await expect(page.getByText('1 site still needs discovery.', { exact: false })).toBeVisible();
+
+  const source = await page.evaluate(() => JSON.parse(localStorage.getItem('bd_acquisition') || '{}'));
+  expect(source).toMatchObject({ source: 'ats-checker', campaign: 'coverage_audit_result' });
+});
+
+test('staffing BD playbook is crawlable and stays within a mobile viewport', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/staffing-bd-playbook');
+
+  await expect(page).toHaveTitle('Staffing Business Development Playbook | BD Engine');
+  await expect(page.getByRole('heading', { name: 'A hiring-signal playbook for staffing business development' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Audit a target list free' })).toBeVisible();
+  await expect(page.locator('link[rel="canonical"]')).toHaveAttribute('href', 'https://bd-engine-production.up.railway.app/staffing-bd-playbook');
+  const viewport = await page.evaluate(() => ({
+    viewportWidth: window.innerWidth,
+    documentWidth: document.documentElement.scrollWidth,
+  }));
+  expect(viewport.documentWidth).toBeLessThanOrEqual(viewport.viewportWidth);
 });
 
 test('ATS checker remains usable on mobile without horizontal overflow', async ({ page }) => {

--- a/saas/test/discoverability.test.js
+++ b/saas/test/discoverability.test.js
@@ -4,6 +4,7 @@ import { readFile } from 'node:fs/promises';
 
 const landingPath = new URL('../public/index.html', import.meta.url);
 const checkerPath = new URL('../public/ats-checker.html', import.meta.url);
+const playbookPath = new URL('../public/staffing-bd-playbook.html', import.meta.url);
 const indexNowKeyPath = new URL('../public/9252ff32fcf3a7589799d0826f50459b.txt', import.meta.url);
 const robotsPath = new URL('../public/robots.txt', import.meta.url);
 const sitemapPath = new URL('../public/sitemap.xml', import.meta.url);
@@ -59,8 +60,32 @@ test('ATS checker is a crawlable no-signup utility with explicit caveats', async
   assert.match(checker, /<link rel="canonical" href="https:\/\/bd-engine-production\.up\.railway\.app\/ats-checker">/);
   assert.match(checker, /The check runs in your browser and does not fetch the submitted site/);
   assert.match(checker, /compatibility signal, not a coverage guarantee/);
+  assert.match(checker, /staffing-bd-playbook/);
   assert.match(checker, /<script type="module" src="\/ats-checker\.js"><\/script>/);
   assert.doesNotMatch(checker, /password|credit card/i);
+});
+
+test('staffing BD playbook publishes focused article and FAQ discovery metadata', async () => {
+  const [playbook, server] = await Promise.all([
+    readFile(playbookPath, 'utf8'),
+    readFile(serverPath, 'utf8'),
+  ]);
+
+  assert.match(playbook, /<link rel="canonical" href="https:\/\/bd-engine-production\.up\.railway\.app\/staffing-bd-playbook">/);
+  assert.match(playbook, /A hiring-signal playbook for staffing business development/);
+  assert.match(playbook, /"@type": "Article"/);
+  assert.match(playbook, /"@type": "FAQPage"/);
+  assert.match(playbook, /BD Engine does not auto-send outreach/);
+  assert.match(server, /getStaffingBdPlaybookHtml/);
+});
+
+test('landing page exposes the free audit and explains the pre-outreach workflow', async () => {
+  const landing = await readFile(landingPath, 'utf8');
+
+  assert.match(landing, /Free ATS audit/);
+  assert.match(landing, /From a target list to the next client conversation/);
+  assert.match(landing, /BD Engine does not auto-send outreach/);
+  assert.match(landing, /staffing-bd-playbook/);
 });
 
 test('landing attribution distinguishes campaigns and records acquisition actions', async () => {
@@ -77,6 +102,9 @@ test('landing attribution distinguishes campaigns and records acquisition action
   assert.match(server, /PUBLIC_ANALYTICS_EVENT_TYPES = new Set\(\['pageview', 'tool_used', 'demo_started', 'signup_started'\]\)/);
   assert.match(server, /buildAcquisitionSource\(acquisition\)/);
   assert.match(await readFile(new URL('../public/ats-checker.js', import.meta.url), 'utf8'), /trackCheckerEvent\('tool_used'\)/);
+  assert.match(await readFile(new URL('../public/ats-checker.js', import.meta.url), 'utf8'), /signup=1&persona=bd/);
+  assert.match(landing, /getInitialAuditSummary/);
+  assert.match(landing, /getRequestedUnauthenticatedView/);
 });
 
 test('crawler files point to the canonical public origin and have explicit MIME types', async () => {
@@ -92,6 +120,7 @@ test('crawler files point to the canonical public origin and have explicit MIME 
   assert.match(sitemap, /<loc>https:\/\/bd-engine-production\.up\.railway\.app\/<\/loc>/);
   assert.match(sitemap, /<loc>https:\/\/bd-engine-production\.up\.railway\.app\/job-search<\/loc>/);
   assert.match(sitemap, /<loc>https:\/\/bd-engine-production\.up\.railway\.app\/ats-checker<\/loc>/);
+  assert.match(sitemap, /<loc>https:\/\/bd-engine-production\.up\.railway\.app\/staffing-bd-playbook<\/loc>/);
   assert.match(server, /getAtsCheckerHtml/);
   assert.match(server, /'\.txt': 'text\/plain; charset=utf-8'/);
   assert.match(server, /'\.xml': 'application\/xml; charset=utf-8'/);


### PR DESCRIPTION
## What changed

- Connects the free ATS coverage audit directly to a contextual 14-day trial signup.
- Carries aggregate audit results into signup without retaining submitted career-site URLs.
- Adds copy-summary and CSV actions to make audit results reusable.
- Adds a homepage operating-loop section and clearer links to the audit and playbook.
- Publishes a crawlable staffing BD playbook with Article and FAQ structured data.
- Adds sitemap coverage and a four-post, UTM-tracked LinkedIn campaign plan.
- Adds focused unit, browser, discoverability, mobile-overflow, and accessibility coverage.

## Why

The ATS checker produced useful evidence but ended as a conversion dead end: its main CTA returned visitors to a broad homepage and discarded the context that created their intent. The landing page also described many features without clearly proving the sequence from target list to client conversation.

This change turns the free utility into a coherent acquisition loop while preserving BD Engine's trust position: explicit denominators, visible unresolved sources, human-reviewed outreach, and no auto-send.

## User and developer impact

Staffing users can audit a target list, reuse the result, and continue directly into a signup form that explains what BD Engine will do next. Search and social visitors also gain a substantive playbook rather than a feature-only destination. Campaign attribution remains attached through signup.

No raw audited URLs are written to session storage; only aggregate counts are carried between pages.

## Validation

- `node --test test/ats-checker.test.js test/discoverability.test.js` — 15/15 passed
- `node --check public/ats-checker.js`
- `node --check src/server.js`
- `git diff --check`
- Static HTML parsing, unique-ID checks, JSON-LD parsing, and CSS brace validation passed

The full npm and Playwright/axe suites could not be executed in the work environment because the locked dependencies and Chromium binary were unavailable.